### PR TITLE
Add methods and new property to demo class

### DIFF
--- a/code/src/NCModel/Features.ts
+++ b/code/src/NCModel/Features.ts
@@ -720,7 +720,10 @@ export class NcDemo extends NcWorker
                 new NcPropertyDescriptor(new NcElementId(3, 3), "numberProperty", "NcUint64", false, false, false, false, new NcParameterConstraintNumber(1000, 0, 1),
                     "Demo numeric property"),
                 new NcPropertyDescriptor(new NcElementId(3, 4), "booleanProperty", "NcBoolean", false, false, false, false, null, "Demo boolean property"),
-                new NcPropertyDescriptor(new NcElementId(3, 5), "objectProperty", "DemoDataType", false, false, false, false, null, "Demo object property")
+                new NcPropertyDescriptor(new NcElementId(3, 5), "objectProperty", "DemoDataType", false, false, false, false, null, "Demo object property"),
+                new NcPropertyDescriptor(new NcElementId(3, 6), "methodNoArgsCount", "NcUint64", true, false, false, false, null, "Method no args invoke counter"),
+                new NcPropertyDescriptor(new NcElementId(3, 7), "methodSimpleArgsCount", "NcUint64", true, false, false, false, null, "Method simple args invoke counter"),
+                new NcPropertyDescriptor(new NcElementId(3, 8), "methodObjectArgCount", "NcUint64", true, false, false, false, null, "Method obj arg invoke counter")
             ],
             [
                 new NcMethodDescriptor(new NcElementId(3, 1), "MethodNoArgs", "NcMethodResultClassDescriptors", [], "Demo method with no arguments"),

--- a/code/src/NCModel/Managers.ts
+++ b/code/src/NCModel/Managers.ts
@@ -3,7 +3,7 @@ import { CommandResponseNoValue, CommandResponseWithValue } from '../NCProtocol/
 import { INotificationContext } from '../SessionManager';
 import { NcBlock } from './Blocks';
 import { NcBlockMemberDescriptor, NcClassDescriptor, NcClassIdentity, NcDatatypeDescriptor, NcDatatypeDescriptorEnum, NcDatatypeDescriptorPrimitive, NcDatatypeDescriptorStruct, NcDatatypeDescriptorTypeDef, NcDatatypeType, NcElementId, NcEnumItemDescriptor, NcFieldDescriptor, NcLockState, NcMethodDescriptor, NcMethodStatus, NcObject, NcParameterDescriptor, NcPort, NcPortReference, NcPropertyDescriptor, NcSignalPath, NcTouchpoint, NcTouchpointNmos, NcTouchpointResource, NcTouchpointResourceNmos } from './Core';
-import { NcDemo, NcGain, NcReceiverMonitor, NcReceiverStatus } from './Features';
+import { DemoDataType, NcDemo, NcGain, NcReceiverMonitor, NcReceiverStatus } from './Features';
 
 export abstract class NcManager extends NcObject
 {
@@ -66,19 +66,19 @@ export class NcClassManager extends NcManager
                             return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'No class identity has been provided');
                     }
                 case '3m2':
-                {
-                    if(args != null && 'name' in args)
                     {
-                        let name = args['name'] as string;
-                        let descriptors = this.GetTypeDescriptors(name);
-                        if(descriptors.length > 0)
-                            return new CommandResponseWithValue(handle, NcMethodStatus.OK, descriptors, null);
+                        if(args != null && 'name' in args)
+                        {
+                            let name = args['name'] as string;
+                            let descriptors = this.GetTypeDescriptors(name);
+                            if(descriptors.length > 0)
+                                return new CommandResponseWithValue(handle, NcMethodStatus.OK, descriptors, null);
+                            else
+                                return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Type name could not be found');
+                        }
                         else
-                            return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Type name could not be found');
+                            return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'No type name has been provided');
                     }
-                    else
-                        return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'No type name has been provided');
-                }
                 default:
                     return super.InvokeMethod(oid, methodId, args, handle);
             }
@@ -306,6 +306,8 @@ export class NcClassManager extends NcManager
                     new NcEnumItemDescriptor("Beta", 2, "Beta option"),
                     new NcEnumItemDescriptor("Gamma", 3, "Gamma option"),
                 ], null, "Demonstration enum data type")];
+            case 'DemoDataType': 
+                return [ DemoDataType.GetTypeDescriptor() ];
             default:
                 return new Array<NcDatatypeDescriptor>();
         }


### PR DESCRIPTION
The demo control class now has:
- demo object property
- demo method with no arguments
- demo method with simple arguments
- demo method with an object argument
- added readonly invoke counter properties for all 3 methods so you can easily see when the method was invoked succesfully.

Tested and can invoke all the methods and read/set the property.