### PR TITLE
Implementation for Subscribing and Unsubscribing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,15 @@ If you plan to make changes and want the app to recompile and run whenever you s
 npm run serve
 ```
 
+`Note`: The configuration file (config.json) holds a `notify_without_subscriptions` key. This is set to false by default, but it can be set to true if you would like to get all notifications on all sessions without subscribing (for debugging purposes only).
+
 ## Specifications
 
-- [AMWA IS-04 NMOS Discovery and Registration](https://specs.amwa.tv/is-04)
-- [AMWA IS-05 NMOS Device Connection Management](https://specs.amwa.tv/is-05)
-- [AMWA IS-12 NMOS Control Protocol](https://specs.amwa.tv/is-12)
-- [MS-05-01 NMOS Control Architecture](https://specs.amwa.tv/ms-05-01)
-- [MS-05-02 NMOS Control Framework](https://specs.amwa.tv/ms-05-02)
-- [MS-05-03 NMOS Control Block Specifications](https://specs.amwa.tv/ms-05-03)
+* [AMWA IS-04 NMOS Discovery and Registration](https://specs.amwa.tv/is-04)
+* [AMWA IS-05 NMOS Device Connection Management](https://specs.amwa.tv/is-05)
+* [AMWA IS-12 NMOS Control Protocol](https://specs.amwa.tv/is-12)
+* [MS-05-01 NMOS Control Architecture](https://specs.amwa.tv/ms-05-01)
+* [MS-05-02 NMOS Control Framework](https://specs.amwa.tv/ms-05-02)
+* [MS-05-03 NMOS Control Block Specifications](https://specs.amwa.tv/ms-05-03)
 
 <!-- INTRO-END -->

--- a/code/config/config.json
+++ b/code/config/config.json
@@ -3,5 +3,6 @@
     "port": 8080,
     "base_label": "NC-01",
     "registry_address": "127.0.0.1",
-    "registry_port": 80
+    "registry_port": 80,
+    "notify_without_subscriptions": false
 }

--- a/code/src/Configuration.ts
+++ b/code/src/Configuration.ts
@@ -13,6 +13,7 @@ export class Configuration implements IConfiguration
     public base_label: string;
     public registry_address: string;
     public registry_port: string;
+    public notify_without_subscriptions: boolean;
 
     public constructor()
     {
@@ -29,6 +30,7 @@ export class Configuration implements IConfiguration
         this.port = config.port;
         this.registry_address = config.registry_address;
         this.registry_port = config.registry_port;
+        this.notify_without_subscriptions = config.notify_without_subscriptions;
 
         this.CheckIdentifiers();
     }
@@ -93,4 +95,5 @@ export interface IConfiguration
     base_label: string;
     registry_address: string;
     registry_port: string;
+    notify_without_subscriptions: boolean;
 }

--- a/code/src/NCModel/Blocks.ts
+++ b/code/src/NCModel/Blocks.ts
@@ -166,7 +166,7 @@ export class NcBlock extends NcObject
         return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'OID could not be found');
     }
 
-    public override InvokeMethod(oid: number, methodId: NcElementId, args: { [key: string]: any; } | null, handle: number): CommandResponseNoValue 
+    public override InvokeMethod(sessionId: number, oid: number, methodId: NcElementId, args: { [key: string]: any; } | null, handle: number): CommandResponseNoValue 
     {
         if(oid == this.oid)
         {
@@ -187,7 +187,7 @@ export class NcBlock extends NcObject
                     }
                     break;
                 default:
-                    return super.InvokeMethod(oid, methodId, args, handle);
+                    return super.InvokeMethod(sessionId, oid, methodId, args, handle);
             }
         }
 
@@ -422,13 +422,13 @@ export class RootBlock extends NcBlock
 
         for (var i = 0; i < command.messages.length; i++) {
             let msg = command.messages[i];
-            responses.AddCommandResponse(this.ProcessCommandMessage(msg));
+            responses.AddCommandResponse(this.ProcessCommandMessage(msg, command.sessionId));
         }
 
         return responses;
     }
 
-    public ProcessCommandMessage(commandMsg: CommandMsg) : CommandResponseNoValue
+    public ProcessCommandMessage(commandMsg: CommandMsg, sessionId: number) : CommandResponseNoValue
     {
         if (this.IsGenericGetter(commandMsg.methodId))
         {
@@ -474,12 +474,12 @@ export class RootBlock extends NcBlock
         else
         {
             if(commandMsg.oid == this.oid)
-                return this.InvokeMethod(commandMsg.oid, commandMsg.methodId, commandMsg.arguments, commandMsg.handle);
+                return this.InvokeMethod(sessionId, commandMsg.oid, commandMsg.methodId, commandMsg.arguments, commandMsg.handle);
             else if(this.memberObjects != null)
             {
                 let member = this.FindNestedMember(commandMsg.oid);
                 if(member)
-                    return member.InvokeMethod(commandMsg.oid, commandMsg.methodId, commandMsg.arguments, commandMsg.handle);
+                    return member.InvokeMethod(sessionId, commandMsg.oid, commandMsg.methodId, commandMsg.arguments, commandMsg.handle);
                 else
                     return new CommandResponseNoValue(commandMsg.handle, NcMethodStatus.InvalidRequest, "OID could not be found");
             }

--- a/code/src/NCModel/Core.ts
+++ b/code/src/NCModel/Core.ts
@@ -143,7 +143,7 @@ export abstract class NcObject
         return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'OID could not be found');
     }
 
-    public InvokeMethod(oid: number, methodId: NcElementId, args: { [key: string]: any } | null, handle: number) : CommandResponseNoValue
+    public InvokeMethod(sessionId: number, oid: number, methodId: NcElementId, args: { [key: string]: any } | null, handle: number) : CommandResponseNoValue
     {
         return new CommandResponseNoValue(handle, NcMethodStatus.BadMethodID, 'Method does not exist in object');
     }
@@ -481,6 +481,35 @@ export class NcClassIdentity extends BaseType
             new NcFieldDescriptor("id", "NcClassId", false, false, null, "Class identity"),
             new NcFieldDescriptor("version", "NcVersionCode", false, false, null, "Class version in semantic versioning format")
         ], null, null, "Class identity and version");
+    }
+
+    public ToJson()
+    {
+        return JSON.stringify(this, jsonIgnoreReplacer);
+    }
+}
+
+export class NcEvent extends BaseType
+{
+    public emitterOid: number;
+    public eventId: NcElementId;
+
+    constructor(
+        emitterOid: number,
+        eventId: NcElementId) 
+    {
+        super();
+
+        this.emitterOid = emitterOid;
+        this.eventId = eventId;
+    }
+
+    public static override GetTypeDescriptor(): NcDatatypeDescriptor
+    {
+        return new NcDatatypeDescriptorStruct("NcEvent", [
+            new NcFieldDescriptor("emitterOid", "NcOid", false, false, null, "Emitter object id"),
+            new NcFieldDescriptor("eventId", "NcElementId", false, false, null, "Event id")
+        ], null, null, "Event identity information");
     }
 
     public ToJson()

--- a/code/src/NCModel/Features.ts
+++ b/code/src/NCModel/Features.ts
@@ -407,7 +407,7 @@ export class NcReceiverMonitor extends NcWorker
         return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'OID could not be found');
     }
 
-    public override InvokeMethod(oid: number, methodId: NcElementId, args: { [key: string]: any; } | null, handle: number): CommandResponseNoValue 
+    public override InvokeMethod(sessionId: number, oid: number, methodId: NcElementId, args: { [key: string]: any; } | null, handle: number): CommandResponseNoValue 
     {
         if(oid == this.oid)
         {
@@ -418,7 +418,7 @@ export class NcReceiverMonitor extends NcWorker
                 case '3m1':
                     return new CommandResponseWithValue(handle, NcMethodStatus.OK, new NcReceiverStatus(this.connectionStatus, this.payloadStatus), null);
                 default:
-                    return super.InvokeMethod(oid, methodId, args, handle);
+                    return super.InvokeMethod(sessionId, oid, methodId, args, handle);
             }
         }
 
@@ -627,7 +627,7 @@ export class NcDemo extends NcWorker
         return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'OID could not be found');
     }
 
-    public override InvokeMethod(oid: number, methodId: NcElementId, args: { [key: string]: any; } | null, handle: number): CommandResponseNoValue 
+    public override InvokeMethod(sessionId: number, oid: number, methodId: NcElementId, args: { [key: string]: any; } | null, handle: number): CommandResponseNoValue 
     {
         if(oid == this.oid)
         {
@@ -700,7 +700,7 @@ export class NcDemo extends NcWorker
                             return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Invalid arguments provided');
                     }
                 default:
-                    return super.InvokeMethod(oid, methodId, args, handle);
+                    return super.InvokeMethod(sessionId, oid, methodId, args, handle);
             }
         }
 

--- a/code/src/Server.ts
+++ b/code/src/Server.ts
@@ -57,7 +57,7 @@ try
 
     myDevice.AddReceiver(myVideoReceiver);
 
-    const sessionManager = new SessionManager();
+    const sessionManager = new SessionManager(config.notify_without_subscriptions);
 
     const classManager = new NcClassManager(
         3,


### PR DESCRIPTION
- initial implementation for subscribing (3m1) and unsubscribing (3m2) to property changed events on different oid's using the SubscriptionManager
- configuration now supports "notify_without_subscriptions" key, which allows when enabled to get all notifications on all sessions without subscribing (for debugging purposes only)
- update README to mention new configuration key.