### PR TITLE
Add sequence property implementation

### DIFF
--- a/code/src/NCModel/Core.ts
+++ b/code/src/NCModel/Core.ts
@@ -129,7 +129,7 @@ export abstract class NcObject
                     return new CommandResponseNoValue(handle, NcMethodStatus.ProcessingFailed, 'Property is readonly');
                 case '1p7':
                     this.userLabel = value;
-                    this.notificationContext.NotifyPropertyChanged(this.oid, id, this.userLabel);
+                    this.notificationContext.NotifyPropertyChanged(this.oid, id, NcPropertyChangeType.ValueChanged, this.userLabel, null);
                     return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
                 case '1p8':
                 case '1p9':
@@ -251,12 +251,10 @@ export enum NcMethodStatus
 
 export enum NcPropertyChangeType
 {
-    CurrentChanged = 0,
-    MinChanged = 1,
-    MaxChanged = 2,
-    ItemAdded = 3,
-    ItemChanged = 4,
-    ItemDeleted = 5
+    ValueChanged = 0,
+    SequenceItemAdded = 1,
+    SequenceItemChanged = 2,
+    SequenceItemRemoved = 3
 }
 
 export enum NcLockState

--- a/code/src/NCModel/Features.ts
+++ b/code/src/NCModel/Features.ts
@@ -893,7 +893,8 @@ export class NcDemo extends NcWorker
                 new NcPropertyDescriptor(new NcElementId(3, 5), "objectProperty", "DemoDataType", false, false, false, false, null, "Demo object property"),
                 new NcPropertyDescriptor(new NcElementId(3, 6), "methodNoArgsCount", "NcUint64", true, false, false, false, null, "Method no args invoke counter"),
                 new NcPropertyDescriptor(new NcElementId(3, 7), "methodSimpleArgsCount", "NcUint64", true, false, false, false, null, "Method simple args invoke counter"),
-                new NcPropertyDescriptor(new NcElementId(3, 8), "methodObjectArgCount", "NcUint64", true, false, false, false, null, "Method obj arg invoke counter")
+                new NcPropertyDescriptor(new NcElementId(3, 8), "methodObjectArgCount", "NcUint64", true, false, false, false, null, "Method obj arg invoke counter"),
+                new NcPropertyDescriptor(new NcElementId(3, 9), "stringSequence", "NcString", false, false, false, true, null, "Demo string sequence property")
             ],
             [
                 new NcMethodDescriptor(new NcElementId(3, 1), "MethodNoArgs", "NcMethodResultClassDescriptors", [], "Demo method with no arguments"),

--- a/code/src/NCModel/Features.ts
+++ b/code/src/NCModel/Features.ts
@@ -1,7 +1,7 @@
 import { jsonIgnoreReplacer, jsonIgnore } from 'json-ignore';
 import { CommandResponseNoValue, CommandResponseWithValue } from '../NCProtocol/Commands';
 import { INotificationContext } from '../SessionManager';
-import { BaseType, myIdDecorator, NcClassDescriptor, NcDatatypeDescriptor, NcDatatypeDescriptorStruct, NcElementId, NcFieldDescriptor, NcLockState, NcMethodDescriptor, NcMethodStatus, NcObject, NcParameterConstraintNumber, NcParameterConstraintString, NcParameterDescriptor, NcPort, NcPropertyDescriptor, NcTouchpoint } from './Core';
+import { BaseType, myIdDecorator, NcClassDescriptor, NcDatatypeDescriptor, NcDatatypeDescriptorStruct, NcElementId, NcFieldDescriptor, NcLockState, NcMethodDescriptor, NcMethodStatus, NcObject, NcParameterConstraintNumber, NcParameterConstraintString, NcParameterDescriptor, NcPort, NcPropertyChangeType, NcPropertyDescriptor, NcTouchpoint } from './Core';
 
 export abstract class NcWorker extends NcObject
 {
@@ -216,7 +216,7 @@ export class NcGain extends NcActuator
             {
                 case '5p1':
                     this.setPoint = value;
-                    this.notificationContext.NotifyPropertyChanged(this.oid, id, this.setPoint);
+                    this.notificationContext.NotifyPropertyChanged(this.oid, id, NcPropertyChangeType.ValueChanged, this.setPoint, null);
                     return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
                 default:
                     return super.Set(oid, id, value, handle);
@@ -344,8 +344,8 @@ export class NcReceiverMonitor extends NcWorker
         this.connectionStatusMessage = null;
         this.payloadStatusMessage = null;
 
-        this.notificationContext.NotifyPropertyChanged(this.oid, new NcElementId(3, 1), this.connectionStatus);
-        this.notificationContext.NotifyPropertyChanged(this.oid, new NcElementId(3, 3), this.payloadStatus);
+        this.notificationContext.NotifyPropertyChanged(this.oid, new NcElementId(3, 1), NcPropertyChangeType.ValueChanged, this.connectionStatus, null);
+        this.notificationContext.NotifyPropertyChanged(this.oid, new NcElementId(3, 3), NcPropertyChangeType.ValueChanged, this.payloadStatus, null);
     }
 
     public Disconnected()
@@ -356,8 +356,8 @@ export class NcReceiverMonitor extends NcWorker
         this.connectionStatusMessage = null;
         this.payloadStatusMessage = null;
 
-        this.notificationContext.NotifyPropertyChanged(this.oid, new NcElementId(3, 1), this.connectionStatus);
-        this.notificationContext.NotifyPropertyChanged(this.oid, new NcElementId(3, 3), this.payloadStatus);
+        this.notificationContext.NotifyPropertyChanged(this.oid, new NcElementId(3, 1), NcPropertyChangeType.ValueChanged, this.connectionStatus, null);
+        this.notificationContext.NotifyPropertyChanged(this.oid, new NcElementId(3, 3), NcPropertyChangeType.ValueChanged, this.payloadStatus, null);
     }
 
     //'1m1'
@@ -528,6 +528,9 @@ export class NcDemo extends NcWorker
     @myIdDecorator('3p8')
     public methodObjectArgCount: number;
 
+    @myIdDecorator('3p9')
+    public stringSequence: string[];
+
     public constructor(
         oid: number,
         constantOid: boolean,
@@ -551,6 +554,7 @@ export class NcDemo extends NcWorker
         this.methodNoArgsCount = 0;
         this.methodSimpleArgsCount = 0;
         this.methodObjectArgCount = 0;
+        this.stringSequence = [ "red", "blue", "green" ];
     }
 
     //'1m1'
@@ -578,6 +582,8 @@ export class NcDemo extends NcWorker
                     return new CommandResponseWithValue(handle, NcMethodStatus.OK, this.methodSimpleArgsCount, null);
                 case '3p8':
                     return new CommandResponseWithValue(handle, NcMethodStatus.OK, this.methodObjectArgCount, null);
+                case '3p9':
+                    return new CommandResponseWithValue(handle, NcMethodStatus.OK, this.stringSequence, null);
                 default:
                     return super.Get(oid, id, handle);
             }
@@ -597,28 +603,32 @@ export class NcDemo extends NcWorker
             {
                 case '3p1':
                     this.enumProperty = value;
-                    this.notificationContext.NotifyPropertyChanged(this.oid, id, this.enumProperty);
+                    this.notificationContext.NotifyPropertyChanged(this.oid, id, NcPropertyChangeType.ValueChanged, this.enumProperty, null);
                     return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
                 case '3p2':
                     this.stringProperty = value;
-                    this.notificationContext.NotifyPropertyChanged(this.oid, id, this.stringProperty);
+                    this.notificationContext.NotifyPropertyChanged(this.oid, id, NcPropertyChangeType.ValueChanged, this.stringProperty, null);
                     return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
                 case '3p3':
                     this.numberProperty = value;
-                    this.notificationContext.NotifyPropertyChanged(this.oid, id, this.numberProperty);
+                    this.notificationContext.NotifyPropertyChanged(this.oid, id, NcPropertyChangeType.ValueChanged, this.numberProperty, null);
                     return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
                 case '3p4':
                     this.booleanProperty = value;
-                    this.notificationContext.NotifyPropertyChanged(this.oid, id, this.booleanProperty);
+                    this.notificationContext.NotifyPropertyChanged(this.oid, id, NcPropertyChangeType.ValueChanged, this.booleanProperty, null);
                     return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
                 case '3p5':
                     this.objectProperty = value;
-                    this.notificationContext.NotifyPropertyChanged(this.oid, id, this.objectProperty);
+                    this.notificationContext.NotifyPropertyChanged(this.oid, id, NcPropertyChangeType.ValueChanged, this.objectProperty, null);
                     return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
                 case '3p6':
                 case '3p7':
                 case '3p8':
                         return new CommandResponseNoValue(handle, NcMethodStatus.Readonly, "Property is read only");
+                case '3p9':
+                    this.stringSequence = value;
+                    this.notificationContext.NotifyPropertyChanged(this.oid, id, NcPropertyChangeType.ValueChanged, this.stringSequence, null);
+                    return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
                 default:
                     return super.Set(oid, id, value, handle);
             }
@@ -635,10 +645,170 @@ export class NcDemo extends NcWorker
 
             switch(key)
             {
+                case '1m3': //GetSequenceItem
+                    {
+                        if(args != null &&
+                            'id' in args &&
+                            'index' in args)
+                        {
+                            let propertyId = args['id'] as NcElementId;
+                            let index = args['index'] as number;
+
+                            if(propertyId)
+                            {
+                                if(index >= 0)
+                                {
+                                    let propertyKey: string = `${propertyId.level}p${propertyId.index}`;
+
+                                    switch(propertyKey)
+                                    {
+                                        case '3p9':
+                                            {
+                                                let itemValue = this.stringSequence[index];
+                                                if(itemValue)
+                                                    return new CommandResponseWithValue(handle, NcMethodStatus.OK, itemValue, null);
+                                                else
+                                                    return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Index could not be found');
+                                            }
+                                        default:
+                                            return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Property could not be found');
+                                    }
+                                }
+                                else
+                                    return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Invalid index argument provided');
+                            }
+                            else
+                                return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Invalid id argument provided');
+                        }
+                        else
+                            return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Invalid arguments provided');
+                    }
+                case '1m4': //SetSequenceItem
+                    {
+                        if(args != null &&
+                            'id' in args &&
+                            'index' in args &&
+                            'value' in args)
+                        {
+                            let propertyId = args['id'] as NcElementId;
+                            let index = args['index'] as number;
+                            let value = args['value'] as string;
+
+                            if(propertyId)
+                            {
+                                if(index >= 0)
+                                {
+                                    let propertyKey: string = `${propertyId.level}p${propertyId.index}`;
+
+                                    switch(propertyKey)
+                                    {
+                                        case '3p9':
+                                            {
+                                                if (this.stringSequence[index] !== undefined) 
+                                                {
+                                                    this.stringSequence[index] = value;
+                                                    this.notificationContext.NotifyPropertyChanged(this.oid, propertyId, NcPropertyChangeType.SequenceItemChanged, value, index);
+
+                                                    return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
+                                                }
+                                                else
+                                                    return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Index could not be found');
+                                            }
+                                        default:
+                                            return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Property could not be found');
+                                    }
+                                }
+                                else
+                                    return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Invalid index argument provided');
+                            }
+                            else
+                                return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Invalid id argument provided');
+                        }
+                        else
+                            return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Invalid arguments provided');
+                    }
+                case '1m5': //AddSequenceItem
+                    {
+                        if(args != null &&
+                            'id' in args &&
+                            'value' in args)
+                        {
+                            let propertyId = args['id'] as NcElementId;
+                            let value = args['value'] as string;
+
+                            if(propertyId)
+                            {
+                                let propertyKey: string = `${propertyId.level}p${propertyId.index}`;
+
+                                switch(propertyKey)
+                                {
+                                    case '3p9':
+                                        {
+                                            this.stringSequence.push(value);
+                                            let index = this.stringSequence.length - 1;
+
+                                            this.notificationContext.NotifyPropertyChanged(this.oid, propertyId, NcPropertyChangeType.SequenceItemAdded, value, index);
+
+                                            return new CommandResponseWithValue(handle, NcMethodStatus.OK, index, null);
+                                        }
+                                    default:
+                                        return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Property could not be found');
+                                }
+                            }
+                            else
+                                return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Invalid id argument provided');
+                        }
+                        else
+                            return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Invalid arguments provided');
+                    }
+                case '1m6': //RemoveSequenceItem
+                    {
+                        if(args != null &&
+                            'id' in args &&
+                            'index' in args)
+                        {
+                            let propertyId = args['id'] as NcElementId;
+                            let index = args['index'] as number;
+
+                            if(propertyId)
+                            {
+                                if(index >= 0)
+                                {
+                                    let propertyKey: string = `${propertyId.level}p${propertyId.index}`;
+
+                                    switch(propertyKey)
+                                    {
+                                        case '3p9':
+                                            {
+                                                if (this.stringSequence[index] !== undefined) 
+                                                {
+                                                    let oldValue = this.stringSequence[index];
+
+                                                    this.stringSequence.splice(index, 1);
+                                                    this.notificationContext.NotifyPropertyChanged(this.oid, propertyId, NcPropertyChangeType.SequenceItemRemoved, oldValue, index);
+
+                                                    return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
+                                                }
+                                                else
+                                                    return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Index could not be found');
+                                            }
+                                        default:
+                                            return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Property could not be found');
+                                    }
+                                }
+                                else
+                                    return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Invalid index argument provided');
+                            }
+                            else
+                                return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Invalid id argument provided');
+                        }
+                        else
+                            return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Invalid arguments provided');
+                    }
                 case '3m1':
                     {
                         this.methodNoArgsCount = this.methodNoArgsCount + 1;
-                        this.notificationContext.NotifyPropertyChanged(this.oid, new NcElementId(3, 6), this.methodNoArgsCount);
+                        this.notificationContext.NotifyPropertyChanged(this.oid, new NcElementId(3, 6), NcPropertyChangeType.ValueChanged, this.methodNoArgsCount, null);
                         return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
                     }
                 case '3m2':
@@ -663,7 +833,7 @@ export class NcDemo extends NcWorker
                                         if(booleanArg !== null)
                                         {
                                             this.methodSimpleArgsCount = this.methodSimpleArgsCount + 1;
-                                            this.notificationContext.NotifyPropertyChanged(this.oid, new NcElementId(3, 7), this.methodSimpleArgsCount);
+                                            this.notificationContext.NotifyPropertyChanged(this.oid, new NcElementId(3, 7), NcPropertyChangeType.ValueChanged, this.methodSimpleArgsCount, null);
                                             return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
                                         }
                                         else
@@ -690,7 +860,7 @@ export class NcDemo extends NcWorker
                             if(objArg)
                             {
                                 this.methodObjectArgCount = this.methodObjectArgCount + 1;
-                                this.notificationContext.NotifyPropertyChanged(this.oid, new NcElementId(3, 8), this.methodObjectArgCount);
+                                this.notificationContext.NotifyPropertyChanged(this.oid, new NcElementId(3, 8), NcPropertyChangeType.ValueChanged, this.methodObjectArgCount, null);
                                 return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
                             }
                             else

--- a/code/src/NCModel/Features.ts
+++ b/code/src/NCModel/Features.ts
@@ -531,6 +531,18 @@ export class NcDemo extends NcWorker
     @myIdDecorator('3p9')
     public stringSequence: string[];
 
+    @myIdDecorator('3p10')
+    public booleanSequence: boolean[];
+
+    @myIdDecorator('3p11')
+    public enumSequence: NcDemoEnum[];
+
+    @myIdDecorator('3p12')
+    public numberSequence: number[];
+
+    @myIdDecorator('3p13')
+    public objectSequence: DemoDataType[];
+
     public constructor(
         oid: number,
         constantOid: boolean,
@@ -555,6 +567,10 @@ export class NcDemo extends NcWorker
         this.methodSimpleArgsCount = 0;
         this.methodObjectArgCount = 0;
         this.stringSequence = [ "red", "blue", "green" ];
+        this.booleanSequence = [ true, false];
+        this.enumSequence = [ NcDemoEnum.Alpha, NcDemoEnum.Gamma ];
+        this.numberSequence = [ 0, 50, 88];
+        this.objectSequence = [ new DemoDataType(NcDemoEnum.Alpha, "demo", 50, false), new DemoDataType(NcDemoEnum.Gamma, "different", 75, true) ];
     }
 
     //'1m1'
@@ -584,6 +600,14 @@ export class NcDemo extends NcWorker
                     return new CommandResponseWithValue(handle, NcMethodStatus.OK, this.methodObjectArgCount, null);
                 case '3p9':
                     return new CommandResponseWithValue(handle, NcMethodStatus.OK, this.stringSequence, null);
+                case '3p10':
+                    return new CommandResponseWithValue(handle, NcMethodStatus.OK, this.booleanSequence, null);
+                case '3p11':
+                    return new CommandResponseWithValue(handle, NcMethodStatus.OK, this.enumSequence, null);
+                case '3p12':
+                    return new CommandResponseWithValue(handle, NcMethodStatus.OK, this.numberSequence, null);
+                case '3p13':
+                    return new CommandResponseWithValue(handle, NcMethodStatus.OK, this.objectSequence, null);
                 default:
                     return super.Get(oid, id, handle);
             }
@@ -629,6 +653,22 @@ export class NcDemo extends NcWorker
                     this.stringSequence = value;
                     this.notificationContext.NotifyPropertyChanged(this.oid, id, NcPropertyChangeType.ValueChanged, this.stringSequence, null);
                     return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
+                case '3p10':
+                    this.booleanSequence = value;
+                    this.notificationContext.NotifyPropertyChanged(this.oid, id, NcPropertyChangeType.ValueChanged, this.booleanSequence, null);
+                    return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
+                case '3p11':
+                    this.enumSequence = value;
+                    this.notificationContext.NotifyPropertyChanged(this.oid, id, NcPropertyChangeType.ValueChanged, this.enumSequence, null);
+                    return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
+                case '3p12':
+                    this.numberSequence = value;
+                    this.notificationContext.NotifyPropertyChanged(this.oid, id, NcPropertyChangeType.ValueChanged, this.numberSequence, null);
+                    return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
+                case '3p13':
+                    this.objectSequence = value;
+                    this.notificationContext.NotifyPropertyChanged(this.oid, id, NcPropertyChangeType.ValueChanged, this.objectSequence, null);
+                    return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
                 default:
                     return super.Set(oid, id, value, handle);
             }
@@ -670,6 +710,38 @@ export class NcDemo extends NcWorker
                                                 else
                                                     return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Index could not be found');
                                             }
+                                        case '3p10':
+                                            {
+                                                let itemValue = this.booleanSequence[index];
+                                                if(itemValue)
+                                                    return new CommandResponseWithValue(handle, NcMethodStatus.OK, itemValue, null);
+                                                else
+                                                    return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Index could not be found');
+                                            }
+                                        case '3p11':
+                                            {
+                                                let itemValue = this.enumSequence[index];
+                                                if(itemValue)
+                                                    return new CommandResponseWithValue(handle, NcMethodStatus.OK, itemValue, null);
+                                                else
+                                                    return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Index could not be found');
+                                            }
+                                        case '3p12':
+                                            {
+                                                let itemValue = this.numberSequence[index];
+                                                if(itemValue !== undefined)
+                                                    return new CommandResponseWithValue(handle, NcMethodStatus.OK, itemValue, null);
+                                                else
+                                                    return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Index could not be found');
+                                            }
+                                        case '3p13':
+                                            {
+                                                let itemValue = this.objectSequence[index];
+                                                if(itemValue)
+                                                    return new CommandResponseWithValue(handle, NcMethodStatus.OK, itemValue, null);
+                                                else
+                                                    return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Index could not be found');
+                                            }
                                         default:
                                             return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Property could not be found');
                                     }
@@ -692,7 +764,6 @@ export class NcDemo extends NcWorker
                         {
                             let propertyId = args['id'] as NcElementId;
                             let index = args['index'] as number;
-                            let value = args['value'] as string;
 
                             if(propertyId)
                             {
@@ -706,10 +777,88 @@ export class NcDemo extends NcWorker
                                             {
                                                 if (this.stringSequence[index] !== undefined) 
                                                 {
-                                                    this.stringSequence[index] = value;
-                                                    this.notificationContext.NotifyPropertyChanged(this.oid, propertyId, NcPropertyChangeType.SequenceItemChanged, value, index);
+                                                    let value = args['value'] as string;
+                                                    if(value !== undefined)
+                                                    {
+                                                        this.stringSequence[index] = value;
+                                                        this.notificationContext.NotifyPropertyChanged(this.oid, propertyId, NcPropertyChangeType.SequenceItemChanged, value, index);
+    
+                                                        return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
+                                                    }
+                                                    else
+                                                        return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Invalid value argument provided');
+                                                }
+                                                else
+                                                    return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Index could not be found');
+                                            }
+                                        case '3p10':
+                                            {
+                                                if (this.booleanSequence[index] !== undefined) 
+                                                {
+                                                    let value = args['value'] as boolean;
+                                                    if(value !== undefined)
+                                                    {
+                                                        this.booleanSequence[index] = value;
+                                                        this.notificationContext.NotifyPropertyChanged(this.oid, propertyId, NcPropertyChangeType.SequenceItemChanged, value, index);
+    
+                                                        return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
+                                                    }
+                                                    else
+                                                        return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Invalid value argument provided');
+                                                }
+                                                else
+                                                    return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Index could not be found');
+                                            }
+                                        case '3p11':
+                                            {
+                                                if (this.enumSequence[index] !== undefined) 
+                                                {
+                                                    let value = args['value'] as NcDemoEnum;
+                                                    if(value !== undefined)
+                                                    {
+                                                        this.enumSequence[index] = value;
+                                                        this.notificationContext.NotifyPropertyChanged(this.oid, propertyId, NcPropertyChangeType.SequenceItemChanged, value, index);
+    
+                                                        return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
+                                                    }
+                                                    else
+                                                        return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Invalid value argument provided');
+                                                }
+                                                else
+                                                    return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Index could not be found');
+                                            }
+                                        case '3p12':
+                                            {
+                                                if (this.numberSequence[index] !== undefined) 
+                                                {
+                                                    let value = args['value'] as number;
+                                                    if(value !== undefined)
+                                                    {
+                                                        this.numberSequence[index] = value;
+                                                        this.notificationContext.NotifyPropertyChanged(this.oid, propertyId, NcPropertyChangeType.SequenceItemChanged, value, index);
+    
+                                                        return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
+                                                    }
+                                                    else
+                                                        return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Invalid value argument provided');
+                                                }
+                                                else
+                                                    return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Index could not be found');
+                                            }
+                                        case '3p13':
+                                            {
+                                                if (this.objectSequence[index] !== undefined) 
+                                                {
+                                                    let value = args['value'] as DemoDataType;
+                                                    if(value !== undefined)
+                                                    {
+                                                        this.objectSequence[index] = value;
+                                                        this.notificationContext.NotifyPropertyChanged(this.oid, propertyId, NcPropertyChangeType.SequenceItemChanged, value, index);
 
-                                                    return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
+                                                        return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
+                                                    }
+                                                    else
+                                                        return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Invalid value argument provided');
                                                 }
                                                 else
                                                     return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Index could not be found');
@@ -734,8 +883,7 @@ export class NcDemo extends NcWorker
                             'value' in args)
                         {
                             let propertyId = args['id'] as NcElementId;
-                            let value = args['value'] as string;
-
+                            
                             if(propertyId)
                             {
                                 let propertyKey: string = `${propertyId.level}p${propertyId.index}`;
@@ -744,12 +892,78 @@ export class NcDemo extends NcWorker
                                 {
                                     case '3p9':
                                         {
-                                            this.stringSequence.push(value);
-                                            let index = this.stringSequence.length - 1;
+                                            let value = args['value'] as string;
+                                            if(value !== undefined)
+                                            {
+                                                this.stringSequence.push(value);
+                                                let index = this.stringSequence.length - 1;
 
-                                            this.notificationContext.NotifyPropertyChanged(this.oid, propertyId, NcPropertyChangeType.SequenceItemAdded, value, index);
+                                                this.notificationContext.NotifyPropertyChanged(this.oid, propertyId, NcPropertyChangeType.SequenceItemAdded, value, index);
 
-                                            return new CommandResponseWithValue(handle, NcMethodStatus.OK, index, null);
+                                                return new CommandResponseWithValue(handle, NcMethodStatus.OK, index, null);
+                                            }
+                                            else
+                                                return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Invalid value argument provided');
+                                        }
+                                    case '3p10':
+                                        {
+                                            let value = args['value'] as boolean;
+                                            if(value !== undefined)
+                                            {
+                                                this.booleanSequence.push(value);
+                                                let index = this.booleanSequence.length - 1;
+
+                                                this.notificationContext.NotifyPropertyChanged(this.oid, propertyId, NcPropertyChangeType.SequenceItemAdded, value, index);
+
+                                                return new CommandResponseWithValue(handle, NcMethodStatus.OK, index, null);
+                                            }
+                                            else
+                                                return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Invalid value argument provided');
+                                        }
+                                    case '3p11':
+                                        {
+                                            let value = args['value'] as NcDemoEnum;
+                                            if(value !== undefined)
+                                            {
+                                                this.enumSequence.push(value);
+                                                let index = this.enumSequence.length - 1;
+
+                                                this.notificationContext.NotifyPropertyChanged(this.oid, propertyId, NcPropertyChangeType.SequenceItemAdded, value, index);
+
+                                                return new CommandResponseWithValue(handle, NcMethodStatus.OK, index, null);
+                                            }
+                                            else
+                                                return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Invalid value argument provided');
+                                        }
+                                    case '3p12':
+                                        {
+                                            let value = args['value'] as number;
+                                            if(value !== undefined)
+                                            {
+                                                this.numberSequence.push(value);
+                                                let index = this.numberSequence.length - 1;
+
+                                                this.notificationContext.NotifyPropertyChanged(this.oid, propertyId, NcPropertyChangeType.SequenceItemAdded, value, index);
+
+                                                return new CommandResponseWithValue(handle, NcMethodStatus.OK, index, null);
+                                            }
+                                            else
+                                                return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Invalid value argument provided');
+                                        }
+                                    case '3p13':
+                                        {
+                                            let value = args['value'] as DemoDataType;
+                                            if(value !== undefined)
+                                            {
+                                                this.objectSequence.push(value);
+                                                let index = this.objectSequence.length - 1;
+
+                                                this.notificationContext.NotifyPropertyChanged(this.oid, propertyId, NcPropertyChangeType.SequenceItemAdded, value, index);
+
+                                                return new CommandResponseWithValue(handle, NcMethodStatus.OK, index, null);
+                                            }
+                                            else
+                                                return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Invalid value argument provided');
                                         }
                                     default:
                                         return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Property could not be found');
@@ -785,6 +999,62 @@ export class NcDemo extends NcWorker
                                                     let oldValue = this.stringSequence[index];
 
                                                     this.stringSequence.splice(index, 1);
+                                                    this.notificationContext.NotifyPropertyChanged(this.oid, propertyId, NcPropertyChangeType.SequenceItemRemoved, oldValue, index);
+
+                                                    return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
+                                                }
+                                                else
+                                                    return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Index could not be found');
+                                            }
+                                        case '3p10':
+                                            {
+                                                if (this.booleanSequence[index] !== undefined) 
+                                                {
+                                                    let oldValue = this.booleanSequence[index];
+
+                                                    this.booleanSequence.splice(index, 1);
+                                                    this.notificationContext.NotifyPropertyChanged(this.oid, propertyId, NcPropertyChangeType.SequenceItemRemoved, oldValue, index);
+
+                                                    return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
+                                                }
+                                                else
+                                                    return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Index could not be found');
+                                            }
+                                        case '3p11':
+                                            {
+                                                if (this.enumSequence[index] !== undefined) 
+                                                {
+                                                    let oldValue = this.enumSequence[index];
+
+                                                    this.enumSequence.splice(index, 1);
+                                                    this.notificationContext.NotifyPropertyChanged(this.oid, propertyId, NcPropertyChangeType.SequenceItemRemoved, oldValue, index);
+
+                                                    return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
+                                                }
+                                                else
+                                                    return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Index could not be found');
+                                            }
+                                        case '3p12':
+                                            {
+                                                if (this.numberSequence[index] !== undefined) 
+                                                {
+                                                    let oldValue = this.numberSequence[index];
+
+                                                    this.numberSequence.splice(index, 1);
+                                                    this.notificationContext.NotifyPropertyChanged(this.oid, propertyId, NcPropertyChangeType.SequenceItemRemoved, oldValue, index);
+
+                                                    return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
+                                                }
+                                                else
+                                                    return new CommandResponseNoValue(handle, NcMethodStatus.InvalidRequest, 'Index could not be found');
+                                            }
+                                        case '3p13':
+                                            {
+                                                if (this.objectSequence[index] !== undefined) 
+                                                {
+                                                    let oldValue = this.objectSequence[index];
+
+                                                    this.objectSequence.splice(index, 1);
                                                     this.notificationContext.NotifyPropertyChanged(this.oid, propertyId, NcPropertyChangeType.SequenceItemRemoved, oldValue, index);
 
                                                     return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
@@ -894,7 +1164,11 @@ export class NcDemo extends NcWorker
                 new NcPropertyDescriptor(new NcElementId(3, 6), "methodNoArgsCount", "NcUint64", true, false, false, false, null, "Method no args invoke counter"),
                 new NcPropertyDescriptor(new NcElementId(3, 7), "methodSimpleArgsCount", "NcUint64", true, false, false, false, null, "Method simple args invoke counter"),
                 new NcPropertyDescriptor(new NcElementId(3, 8), "methodObjectArgCount", "NcUint64", true, false, false, false, null, "Method obj arg invoke counter"),
-                new NcPropertyDescriptor(new NcElementId(3, 9), "stringSequence", "NcString", false, false, false, true, null, "Demo string sequence property")
+                new NcPropertyDescriptor(new NcElementId(3, 9), "stringSequence", "NcString", false, false, false, true, null, "Demo string sequence property"),
+                new NcPropertyDescriptor(new NcElementId(3, 10), "booleanSequence", "NcBoolean", false, false, false, true, null, "Demo boolean sequence property"),
+                new NcPropertyDescriptor(new NcElementId(3, 11), "enumSequence", "NcDemoEnum", false, false, false, true, null, "Demo enum sequence property"),
+                new NcPropertyDescriptor(new NcElementId(3, 12), "numberSequence", "NcUint64", false, false, false, true, null, "Demo number sequence property"),
+                new NcPropertyDescriptor(new NcElementId(3, 13), "objectSequence", "DemoDataType", false, false, false, true, null, "Demo object sequence property")
             ],
             [
                 new NcMethodDescriptor(new NcElementId(3, 1), "MethodNoArgs", "NcMethodResultClassDescriptors", [], "Demo method with no arguments"),

--- a/code/src/NCModel/Managers.ts
+++ b/code/src/NCModel/Managers.ts
@@ -1,9 +1,9 @@
 import { jsonIgnoreReplacer, jsonIgnore } from 'json-ignore';
 import { CommandResponseNoValue, CommandResponseWithValue } from '../NCProtocol/Commands';
-import { NcEventData } from '../NCProtocol/Notifications';
+import { NcPropertyChangedEventData } from '../NCProtocol/Notifications';
 import { INotificationContext } from '../SessionManager';
 import { NcBlock } from './Blocks';
-import { BaseType, myIdDecorator, NcBlockMemberDescriptor, NcClassDescriptor, NcClassIdentity, NcDatatypeDescriptor, NcDatatypeDescriptorEnum, NcDatatypeDescriptorPrimitive, NcDatatypeDescriptorStruct, NcDatatypeDescriptorTypeDef, NcDatatypeType, NcElementId, NcEnumItemDescriptor, NcEvent, NcFieldDescriptor, NcLockState, NcMethodDescriptor, NcMethodStatus, NcObject, NcParameterDescriptor, NcPort, NcPortReference, NcPropertyDescriptor, NcSignalPath, NcTouchpoint, NcTouchpointNmos, NcTouchpointResource, NcTouchpointResourceNmos } from './Core';
+import { BaseType, myIdDecorator, NcBlockMemberDescriptor, NcClassDescriptor, NcClassIdentity, NcDatatypeDescriptor, NcDatatypeDescriptorEnum, NcDatatypeDescriptorPrimitive, NcDatatypeDescriptorStruct, NcDatatypeDescriptorTypeDef, NcDatatypeType, NcElementId, NcEnumItemDescriptor, NcEvent, NcFieldDescriptor, NcLockState, NcMethodDescriptor, NcMethodStatus, NcObject, NcParameterDescriptor, NcPort, NcPortReference, NcPropertyChangeType, NcPropertyDescriptor, NcSignalPath, NcTouchpoint, NcTouchpointNmos, NcTouchpointResource, NcTouchpointResourceNmos } from './Core';
 import { DemoDataType, NcDemo, NcGain, NcReceiverMonitor, NcReceiverStatus } from './Features';
 
 export abstract class NcManager extends NcObject
@@ -260,15 +260,15 @@ export class NcDeviceManager extends NcManager
                     return new CommandResponseNoValue(handle, NcMethodStatus.ProcessingFailed, 'Property is readonly');
                 case '3p5':
                     this.userInventoryCode = value;
-                    this.notificationContext.NotifyPropertyChanged(this.oid, id, this.userInventoryCode);
+                    this.notificationContext.NotifyPropertyChanged(this.oid, id, NcPropertyChangeType.ValueChanged, this.userInventoryCode, null);
                     return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
                 case '3p6':
                     this.deviceName = value;
-                    this.notificationContext.NotifyPropertyChanged(this.oid, id, this.deviceName);
+                    this.notificationContext.NotifyPropertyChanged(this.oid, id, NcPropertyChangeType.ValueChanged, this.deviceName, null);
                     return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
                 case '3p7':
                     this.deviceRole = value;
-                    this.notificationContext.NotifyPropertyChanged(this.oid, id, this.deviceRole);
+                    this.notificationContext.NotifyPropertyChanged(this.oid, id, NcPropertyChangeType.ValueChanged, this.deviceRole, null);
                     return new CommandResponseNoValue(handle, NcMethodStatus.OK, null);
                 default:
                     return super.Set(oid, id, value, handle);
@@ -512,11 +512,20 @@ export class NcClassManager extends NcManager
                 return [ new NcDatatypeDescriptorTypeDef("NcPropertyId", "NcElementId", false, null, "Class property id which contains the level and index")];
             case 'NcElementId': 
                 return [ NcElementId.GetTypeDescriptor() ];
+            case 'NcPropertyChangeType': 
+                return [ new NcDatatypeDescriptorEnum("NcPropertyChangeType", [
+                    new NcEnumItemDescriptor("ValueChanged", 0, "Current value changed"),
+                    new NcEnumItemDescriptor("SequenceItemAdded", 1, "Sequence item added"),
+                    new NcEnumItemDescriptor("SequenceItemChanged", 2, "Sequence item changed"),
+                    new NcEnumItemDescriptor("SequenceItemRemoved", 3, "Sequence item removed")
+                ], null, "Type of property change")];
+            case 'NcPropertyChangedEventData': 
+                return [ NcPropertyChangedEventData.GetTypeDescriptor() ];
             case 'NcLockState': 
                 return [ new NcDatatypeDescriptorEnum("NcLockState", [
                     new NcEnumItemDescriptor("MoLock", 0, "Not locked"),
                     new NcEnumItemDescriptor("NockNoWrite", 1, "Locked for write operations"),
-                    new NcEnumItemDescriptor("LockNoReadWrite", 2, "Locked for both read and write operations"),
+                    new NcEnumItemDescriptor("LockNoReadWrite", 2, "Locked for both read and write operations")
                 ], null, "Lock state enum data type")];
             case 'NcMethodStatus': 
                 return [ new NcDatatypeDescriptorEnum("NcMethodStatus", [
@@ -536,7 +545,7 @@ export class NcClassManager extends NcManager
                     new NcEnumItemDescriptor("PartiallySucceeded", 13, "Addressed method began executing but stopped before completing"),
                     new NcEnumItemDescriptor("Timeout", 14, "Method call did not finish within the allotted time"),
                     new NcEnumItemDescriptor("BufferOverflow", 15, "Something was too big"),
-                    new NcEnumItemDescriptor("OmittedProperty", 16, "Command referenced an optional property that is not instantiated in the referenced object"),
+                    new NcEnumItemDescriptor("OmittedProperty", 16, "Command referenced an optional property that is not instantiated in the referenced object")
                 ], null, "Method invokation status")];
             case 'NcMethodResult':
                 return [ new NcDatatypeDescriptorStruct("NcMethodResult", [
@@ -580,21 +589,21 @@ export class NcClassManager extends NcManager
                     new NcEnumItemDescriptor("Undefined", 0, "Not defined"),
                     new NcEnumItemDescriptor("Input", 1, "Input direction"),
                     new NcEnumItemDescriptor("Output", 2, "Output direction"),
-                    new NcEnumItemDescriptor("Bidirectional", 3, "Bidirectional"),
+                    new NcEnumItemDescriptor("Bidirectional", 3, "Bidirectional")
                 ], null, "Input and/or output direction")];
             case 'NcConnectionStatus': 
                 return [ new NcDatatypeDescriptorEnum("NcConnectionStatus", [
                     new NcEnumItemDescriptor("Undefined", 0, "This is the value when there is no receiver"),
                     new NcEnumItemDescriptor("Connected", 1, "Connected to a stream"),
                     new NcEnumItemDescriptor("Disconnected", 2, "Not connected to a stream"),
-                    new NcEnumItemDescriptor("ConnectionError", 3, "A connection error was encountered"),
+                    new NcEnumItemDescriptor("ConnectionError", 3, "A connection error was encountered")
                 ], null, "Connection status enum data type")];
             case 'NcPayloadStatus': 
                 return [ new NcDatatypeDescriptorEnum("NcPayloadStatus", [
                     new NcEnumItemDescriptor("Undefined", 0, "This is the value when there's no connection."),
                     new NcEnumItemDescriptor("PayloadOK", 1, "Payload is being received without errors and is the correct type"),
                     new NcEnumItemDescriptor("PayloadFormatUnsupported", 2, "Payload is being received but is of an unsupported type"),
-                    new NcEnumItemDescriptor("PayloadError", 3, "A payload error was encountered"),
+                    new NcEnumItemDescriptor("PayloadError", 3, "A payload error was encountered")
                 ], null, "Payload status enum data type")];
             case 'NcPort': 
                 return [ NcPort.GetTypeDescriptor() ];
@@ -615,7 +624,7 @@ export class NcClassManager extends NcManager
                     new NcEnumItemDescriptor("Undefined", 0, "Not defined option"),
                     new NcEnumItemDescriptor("Alpha", 1, "Alpha option"),
                     new NcEnumItemDescriptor("Beta", 2, "Beta option"),
-                    new NcEnumItemDescriptor("Gamma", 3, "Gamma option"),
+                    new NcEnumItemDescriptor("Gamma", 3, "Gamma option")
                 ], null, "Demonstration enum data type")];
             case 'DemoDataType': 
                 return [ DemoDataType.GetTypeDescriptor() ];

--- a/code/src/NCProtocol/Notifications.ts
+++ b/code/src/NCProtocol/Notifications.ts
@@ -1,25 +1,46 @@
 import exp from 'constants';
 import { jsonIgnoreReplacer, jsonIgnore } from 'json-ignore';
-import { NcElementId, NcPropertyChangeType } from '../NCModel/Core';
+import { BaseType, NcDatatypeDescriptor, NcDatatypeDescriptorStruct, NcElementId, NcFieldDescriptor, NcPropertyChangeType } from '../NCModel/Core';
 
 import { MessageType, ProtocolWrapper } from './Core';
 
-export class NcEventData
+export class NcPropertyChangedEventData extends BaseType
 {
     public propertyId: NcElementId;
 
     public changeType: NcPropertyChangeType;
 
-    public propertyValue: any | null;
+    public value: any | null;
+
+    public sequenceItemIndex: number | null;
 
     constructor(
         propertyId: NcElementId,
         changeType: NcPropertyChangeType,
-        propertyValue: any | null)
+        value: any | null,
+        sequenceItemIndex: number | null)
     {
+        super();
+
         this.propertyId = propertyId;
         this.changeType = changeType;
-        this.propertyValue = propertyValue;
+        this.value = value;
+        this.sequenceItemIndex = sequenceItemIndex;
+    }
+
+    public static override GetTypeDescriptor(): NcDatatypeDescriptor
+    {
+        return new NcDatatypeDescriptorStruct("NcPropertyChangedEventData", [
+            new NcFieldDescriptor("propertyId", "NcElementId", false, false, null, "ID of changed property"),
+            new NcFieldDescriptor("changeType", "NcPropertyChangeType", false, false, null, "Information regarding the change type"),
+            new NcFieldDescriptor("value", null, true, false, null, "Property-type specific value"),
+            new NcFieldDescriptor("sequenceItemIndex", "NcId32", true, false, null, "Index of sequence item if the property is a sequence")
+        ], null, null, "Payload of property-changed event");
+    }
+
+    public ToJson()
+    {
+        return JSON.stringify(this, jsonIgnoreReplacer);
     }
 }
 
@@ -37,12 +58,12 @@ export class NcNotification
 
     public eventId: NcElementId;
 
-    public eventData: NcEventData;
+    public eventData: NcPropertyChangedEventData;
 
     constructor(
         oid: number,
         eventId: NcElementId,
-        eventData: NcEventData)
+        eventData: NcPropertyChangedEventData)
     {
         this.oid = oid;
         this.eventId = eventId;

--- a/code/src/SessionManager.ts
+++ b/code/src/SessionManager.ts
@@ -2,11 +2,11 @@ import { jsonIgnoreReplacer, jsonIgnore } from 'json-ignore';
 
 import { WebSocketConnection } from './Server';
 import { NcElementId, NcMethodStatus, NcPropertyChangeType } from './NCModel/Core';
-import { NcEventData, NcNotification, ProtoNotification } from './NCProtocol/Notifications';
+import { NcPropertyChangedEventData, NcNotification, ProtoNotification } from './NCProtocol/Notifications';
 
 export interface INotificationContext
 {
-    NotifyPropertyChanged(oid: number, propertyId: NcElementId, value: any);
+    NotifyPropertyChanged(oid: number, propertyId: NcElementId, changeType: NcPropertyChangeType, value: any | null, sequenceItemIndex: number | null);
     Subscribe(sessionId: number, oid: number);
     UnSubscribe(sessionId: number, oid: number);
     CreateSession(socket: WebSocketConnection, heartBeatTime: number) : [number | null, string | null]
@@ -41,7 +41,7 @@ export class SessionManager implements INotificationContext
             sub.UnSubscribe(oid);
     }
 
-    public NotifyPropertyChanged(oid: number, propertyId: NcElementId, value: any)
+    public NotifyPropertyChanged(oid: number, propertyId: NcElementId, changeType: NcPropertyChangeType, value: any | null, sequenceItemIndex: number | null)
     {
         console.log(`NotifyPropertyChanged oid: ${oid}, property: ${propertyId.level}p${propertyId.index}, value: ${JSON.stringify(value)}`);
 
@@ -53,7 +53,7 @@ export class SessionManager implements INotificationContext
                 session.socket.send(
                     new ProtoNotification(
                         session.sessionId,
-                        [ new NcNotification(oid, new NcElementId(1, 1), new NcEventData(propertyId, NcPropertyChangeType.CurrentChanged, value)) ]
+                        [ new NcNotification(oid, new NcElementId(1, 1), new NcPropertyChangedEventData(propertyId, changeType, value, sequenceItemIndex)) ]
                     ).ToJson());
             }
         }


### PR DESCRIPTION
Add sequence property implementation in NcDemo control class.
- Contains changes and validates the associated MS-05-02 PR: https://github.com/AMWA-TV/ms-05-02/pull/27
- NcDemo implements the required methods: GetSequenceItem (1m3), SetSequenceItem (1m4), AddSequenceItem (1m5), RemoveSequenceItem (1m6)

Added sequence properties for the following relevant types:
- booleanSequence (3p10)
- enumSequence (3p11)
- numberSequence (3p12)
- objectSequence (3p13)

Tested manually with a WebSocket extension invoking the relevant methods for all the new properties and with a controller.