### PR TITLE
Changes as per 21/02/2023 meeting 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,12 @@ If you plan to make changes and want the app to recompile and run whenever you s
 npm run serve
 ```
 
-`Note`: The configuration file (config.json) holds a `notify_without_subscriptions` key. This is set to false by default, but it can be set to true if you would like to get all notifications on all sessions without subscribing (for debugging purposes only).
+## Configuration
+
+These are the configuration keys which can be specified in the configuration file (config.json):
+
+* notify_without_subscriptions - boolean flag which is set to false by default, but it can be set to true if you would like to get all notifications on all sessions without subscribing (for debugging purposes only).
+* work_without_registry - boolean flag which is set to false by default, but it can be set to true if you would like the mock device not to attempt to register with an NMOS registry.
 
 ## Specifications
 

--- a/code/config/config.json
+++ b/code/config/config.json
@@ -4,5 +4,6 @@
     "base_label": "NC-01",
     "registry_address": "127.0.0.1",
     "registry_port": 80,
-    "notify_without_subscriptions": false
+    "notify_without_subscriptions": false,
+    "work_without_registry": false
 }

--- a/code/src/Configuration.ts
+++ b/code/src/Configuration.ts
@@ -14,6 +14,7 @@ export class Configuration implements IConfiguration
     public registry_address: string;
     public registry_port: string;
     public notify_without_subscriptions: boolean;
+    public work_without_registry: boolean;
 
     public constructor()
     {
@@ -31,6 +32,7 @@ export class Configuration implements IConfiguration
         this.registry_address = config.registry_address;
         this.registry_port = config.registry_port;
         this.notify_without_subscriptions = config.notify_without_subscriptions;
+        this.work_without_registry = config.work_without_registry;
 
         this.CheckIdentifiers();
     }
@@ -96,4 +98,5 @@ export interface IConfiguration
     registry_address: string;
     registry_port: string;
     notify_without_subscriptions: boolean;
+    work_without_registry: boolean;
 }

--- a/code/src/NCModel/Blocks.ts
+++ b/code/src/NCModel/Blocks.ts
@@ -1,5 +1,5 @@
 import { jsonIgnoreReplacer, jsonIgnore } from 'json-ignore';
-import { CommandMsg, CommandResponseError, CommandResponseNoValue, CommandResponseWithValue, ProtoCommand, ProtoCommandResponse, ProtoError } from '../NCProtocol/Commands';
+import { CommandMsg, CommandResponseError, CommandResponseNoValue, CommandResponseWithValue, ProtocolCommand, ProtocolCommandResponse, ProtocolError } from '../NCProtocol/Commands';
 import { MessageType, ProtocolWrapper } from '../NCProtocol/Core';
 import { WebSocketConnection } from '../Server';
 import { INotificationContext } from '../SessionManager';
@@ -545,7 +545,7 @@ export class RootBlock extends NcBlock
             {
                 case MessageType.Command:
                 {
-                    let msgCommand = JSON.parse(msg) as ProtoCommand;
+                    let msgCommand = JSON.parse(msg) as ProtocolCommand;
                     socket.send(this.ProcessCommand(msgCommand, socket).ToJson());
                     isMessageValid = true;
                 }
@@ -568,14 +568,14 @@ export class RootBlock extends NcBlock
         if(isMessageValid == false)
         {
             console.log(errorMessage);
-            let error = new ProtoError(status, errorMessage);
+            let error = new ProtocolError(status, errorMessage);
             socket.send(error.ToJson());
         }
     }
 
-    public ProcessCommand(command: ProtoCommand, socket: WebSocketConnection) : ProtoCommandResponse
+    public ProcessCommand(command: ProtocolCommand, socket: WebSocketConnection) : ProtocolCommandResponse
     {
-        let responses = new ProtoCommandResponse([]);
+        let responses = new ProtocolCommandResponse([]);
 
         for (var i = 0; i < command.commands.length; i++) {
             let msg = command.commands[i];

--- a/code/src/NCModel/Blocks.ts
+++ b/code/src/NCModel/Blocks.ts
@@ -8,13 +8,13 @@ import {
     NcBlockDescriptor,
     NcBlockMemberDescriptor,
     NcClassDescriptor,
-    NcClassIdentity,
     NcElementId,
     NcMethodDescriptor,
     NcMethodStatus,
     NcObject,
     NcParameterDescriptor,
     NcPort,
+    NcPropertyConstraints,
     NcPropertyDescriptor,
     NcSignalPath,
     NcTouchpoint } from './Core';
@@ -22,13 +22,9 @@ import {
 export class NcBlock extends NcObject
 {
     public static staticClassID: number[] = [ 1, 1 ];
-    public static staticClassVersion: string = "1.0.0";
 
     @myIdDecorator('1p1')
     public override classID: number[] = NcBlock.staticClassID;
-
-    @myIdDecorator('1p2')
-    public override classVersion: string = NcBlock.staticClassVersion;
 
     @myIdDecorator('2p1')
     public isRoot: boolean;
@@ -76,6 +72,7 @@ export class NcBlock extends NcObject
         role: string,
         userLabel: string,
         touchpoints: NcTouchpoint[] | null,
+        runtimePropertyConstraints: NcPropertyConstraints[] | null,
         enabled: boolean,
         specId: string | null,
         specVersion: string | null,
@@ -89,7 +86,7 @@ export class NcBlock extends NcObject
         description: string,
         notificationContext: INotificationContext)
     {
-        super(oid, constantOid, owner, role, userLabel, touchpoints, description, notificationContext);
+        super(oid, constantOid, owner, role, userLabel, touchpoints, runtimePropertyConstraints, description, notificationContext);
 
         this.isRoot = isRoot;
         this.enabled = enabled;
@@ -280,7 +277,7 @@ export class NcBlock extends NcObject
 
     public override GenerateMemberDescriptor() : NcBlockMemberDescriptor
     {
-        return new NcBlockDescriptor(this.specId, this.role, this.oid, this.constantOid, new NcClassIdentity(this.classID, this.classVersion), this.userLabel, this.owner, this.description, null);
+        return new NcBlockDescriptor(this.specId, this.role, this.oid, this.constantOid, this.classID, this.userLabel, this.owner, this.description, null);
     }
 
     public FindNestedMember(oid: number): NcObject | null
@@ -318,7 +315,7 @@ export class NcBlock extends NcObject
     public static override GetClassDescriptor(includeInherited: boolean): NcClassDescriptor 
     {
         let currentClassDescriptor = new NcClassDescriptor(`${NcBlock.name} class descriptor`,
-            new NcClassIdentity(NcBlock.staticClassID, NcBlock.staticClassVersion), NcBlock.name, null,
+            NcBlock.staticClassID, NcBlock.name, null,
             [
                 new NcPropertyDescriptor(new NcElementId(2, 1), "isRoot", "NcBoolean", true, true, false, false, null, "TRUE if block is the root block"),
                 new NcPropertyDescriptor(new NcElementId(2, 2), "specId", "NcString", true, true, true, false, null, "Global ID of blockSpec that defines this block"),
@@ -496,6 +493,7 @@ export class RootBlock extends NcBlock
         role: string,
         userLabel: string,
         touchpoints: NcTouchpoint[] | null,
+        runtimePropertyConstraints: NcPropertyConstraints[] | null,
         enabled: boolean,
         specId: string | null,
         specVersion: string | null,
@@ -517,6 +515,7 @@ export class RootBlock extends NcBlock
             role,
             userLabel,
             touchpoints,
+            runtimePropertyConstraints,
             enabled,
             specId,
             specVersion,

--- a/code/src/NCModel/Core.ts
+++ b/code/src/NCModel/Core.ts
@@ -20,31 +20,30 @@ export abstract class NcObject
     public notificationContext: INotificationContext;
 
     public static staticClassID: number[] = [ 1 ];
-    public static staticClassVersion: string = "1.0.0";
 
     @myIdDecorator('1p1')
     public classID: number[] = NcObject.staticClassID;
 
     @myIdDecorator('1p2')
-    public classVersion: string = NcObject.staticClassVersion;
-
-    @myIdDecorator('1p3')
     public oid: number;
 
-    @myIdDecorator('1p4')
+    @myIdDecorator('1p3')
     public constantOid: boolean;
 
-    @myIdDecorator('1p5')
+    @myIdDecorator('1p4')
     public owner: number | null
 
-    @myIdDecorator('1p6')
+    @myIdDecorator('1p5')
     public role: string;
 
-    @myIdDecorator('1p7')
+    @myIdDecorator('1p6')
     public userLabel: string | null;
 
-    @myIdDecorator('1p8')
+    @myIdDecorator('1p7')
     public touchpoints: NcTouchpoint[] | null;
+
+    @myIdDecorator('1p8')
+    public runtimePropertyConstraints: NcPropertyConstraints[] | null;
 
     public description: string;
 
@@ -55,6 +54,7 @@ export abstract class NcObject
         role: string,
         userLabel: string | null,
         touchpoints: NcTouchpoint[] | null,
+        runtimePropertyConstraints: NcPropertyConstraints[] | null,
         description: string,
         notificationContext: INotificationContext)
     {
@@ -64,6 +64,7 @@ export abstract class NcObject
         this.role = role;
         this.userLabel = userLabel;
         this.touchpoints = touchpoints;
+        this.runtimePropertyConstraints = runtimePropertyConstraints;
         this.description = description;
         this.notificationContext = notificationContext;
     }
@@ -80,19 +81,19 @@ export abstract class NcObject
                 case '1p1':
                     return new CommandResponseWithValue(handle, NcMethodStatus.OK, this.classID);
                 case '1p2':
-                    return new CommandResponseWithValue(handle, NcMethodStatus.OK, this.classVersion);
-                case '1p3':
                     return new CommandResponseWithValue(handle, NcMethodStatus.OK, this.oid);
-                case '1p4':
+                case '1p3':
                     return new CommandResponseWithValue(handle, NcMethodStatus.OK, this.constantOid);
-                case '1p5':
+                case '1p4':
                     return new CommandResponseWithValue(handle, NcMethodStatus.OK, this.owner);
-                case '1p6':
+                case '1p5':
                     return new CommandResponseWithValue(handle, NcMethodStatus.OK, this.role);
-                case '1p7':
+                case '1p6':
                     return new CommandResponseWithValue(handle, NcMethodStatus.OK, this.userLabel);
-                case '1p8':
+                case '1p7':
                     return new CommandResponseWithValue(handle, NcMethodStatus.OK, this.touchpoints);
+                case '1p8':
+                    return new CommandResponseWithValue(handle, NcMethodStatus.OK, this.runtimePropertyConstraints);
                 default:
                     return new CommandResponseError(handle, NcMethodStatus.PropertyNotImplemented, 'Property does not exist in object');
             }
@@ -115,12 +116,12 @@ export abstract class NcObject
                 case '1p3':
                 case '1p4':
                 case '1p5':
-                case '1p6':
                     return new CommandResponseError(handle, NcMethodStatus.Readonly, 'Property is readonly');
-                case '1p7':
+                case '1p6':
                     this.userLabel = value;
                     this.notificationContext.NotifyPropertyChanged(this.oid, id, NcPropertyChangeType.ValueChanged, this.userLabel, null);
                     return new CommandResponseNoValue(handle, NcMethodStatus.OK);
+                case '1p7':
                 case '1p8':
                     return new CommandResponseError(handle, NcMethodStatus.Readonly, 'Property is readonly');
                 default:
@@ -138,22 +139,22 @@ export abstract class NcObject
 
     public GenerateMemberDescriptor() : NcBlockMemberDescriptor
     {
-        return new NcBlockMemberDescriptor(this.role, this.oid, this.constantOid, new NcClassIdentity(this.classID, this.classVersion), this.userLabel, this.owner, this.description, null);
+        return new NcBlockMemberDescriptor(this.role, this.oid, this.constantOid, this.classID, this.userLabel, this.owner, this.description, null);
     }
 
     public static GetClassDescriptor(includeInherited: boolean) : NcClassDescriptor
     {
         return new NcClassDescriptor(`${NcObject.name} class descriptor`,
-            new NcClassIdentity(NcObject.staticClassID, NcObject.staticClassVersion), NcObject.name, null,
+            NcObject.staticClassID, NcObject.name, null,
             [ 
                 new NcPropertyDescriptor(new NcElementId(1, 1), "classId", "NcClassId", true, true, false, false, null, "Class identity"),
-                new NcPropertyDescriptor(new NcElementId(1, 2), "classVersion", "NcVersionCode", true, true, false, false, null, "Class version"),
-                new NcPropertyDescriptor(new NcElementId(1, 3), "oid", "NcOid", true, true, false, false, null, "Object identifier"),
-                new NcPropertyDescriptor(new NcElementId(1, 4), "constantOid", "NcBoolean", true, true, false, false, null, "TRUE iff OID is hardwired into device"),
-                new NcPropertyDescriptor(new NcElementId(1, 5), "owner", "NcOid", true, true, true, false, null, "OID of containing block. Can only ever be null for the root block" ),
-                new NcPropertyDescriptor(new NcElementId(1, 6), "role", "NcString", true, true, false, false, null, "role of obj in containing block"),
-                new NcPropertyDescriptor(new NcElementId(1, 7), "userLabel", "NcString", false, true, true, false, null, "Scribble strip"),
-                new NcPropertyDescriptor(new NcElementId(1, 8), "touchpoints", "NcTouchpoint", true, true, true, true, null, "Touchpoints to other contexts"),
+                new NcPropertyDescriptor(new NcElementId(1, 2), "oid", "NcOid", true, true, false, false, null, "Object identifier"),
+                new NcPropertyDescriptor(new NcElementId(1, 3), "constantOid", "NcBoolean", true, true, false, false, null, "TRUE iff OID is hardwired into device"),
+                new NcPropertyDescriptor(new NcElementId(1, 4), "owner", "NcOid", true, true, true, false, null, "OID of containing block. Can only ever be null for the root block" ),
+                new NcPropertyDescriptor(new NcElementId(1, 5), "role", "NcString", true, true, false, false, null, "role of obj in containing block"),
+                new NcPropertyDescriptor(new NcElementId(1, 6), "userLabel", "NcString", false, true, true, false, null, "Scribble strip"),
+                new NcPropertyDescriptor(new NcElementId(1, 7), "touchpoints", "NcTouchpoint", true, true, true, true, null, "Touchpoints to other contexts"),
+                new NcPropertyDescriptor(new NcElementId(1, 8), "runtimePropertyConstraints", "NcPropertyConstraints", true, true, true, true, null, "Runtime property constraints"),
             ],
             [ 
                 new NcMethodDescriptor(new NcElementId(1, 1), "Get", "NcMethodResultPropertyValue", [
@@ -218,6 +219,8 @@ export class NcElementId extends BaseType
 export enum NcMethodStatus
 {
     OK = 200,
+    PropertyDeprecated = 298,
+    MethodDeprecated = 299,
     BadCommandFormat = 400,
     Unauthorized = 401,
     BadOid = 404,
@@ -447,35 +450,6 @@ export class NcTouchpointNmos extends NcTouchpoint
     }
 }
 
-export class NcClassIdentity extends BaseType
-{
-    public id: number[];
-    public version: string;
-
-    constructor(
-        id: number[],
-        version: string) 
-    {
-        super();
-
-        this.id = id;
-        this.version = version;
-    }
-
-    public static override GetTypeDescriptor(includeInherited: boolean): NcDatatypeDescriptor
-    {
-        return new NcDatatypeDescriptorStruct("NcClassIdentity", [
-            new NcFieldDescriptor("id", "NcClassId", false, false, null, "Class identity"),
-            new NcFieldDescriptor("version", "NcVersionCode", false, false, null, "Class version in semantic versioning format")
-        ], null, null, "Class identity and version");
-    }
-
-    public ToJson()
-    {
-        return JSON.stringify(this, jsonIgnoreReplacer);
-    }
-}
-
 export abstract class NcDescriptor
 {
     public description: string;
@@ -492,7 +466,7 @@ export class NcBlockMemberDescriptor extends BaseType
     public role: string;
     public oid: number;
     public constantOid: boolean;
-    public identity: NcClassIdentity;
+    public classId: number[];
     public userLabel: string | null;
     public owner: number | null;
     public description: string;
@@ -502,7 +476,7 @@ export class NcBlockMemberDescriptor extends BaseType
         role: string,
         oid: number,
         constantOid: boolean,
-        identity: NcClassIdentity,
+        classId: number[],
         userLabel: string | null,
         owner: number | null,
         description: string,
@@ -513,7 +487,7 @@ export class NcBlockMemberDescriptor extends BaseType
         this.role = role;
         this.oid = oid;
         this.constantOid = constantOid;
-        this.identity = identity;
+        this.classId = classId;
         this.userLabel = userLabel;
         this.owner = owner;
         this.description = description;
@@ -526,7 +500,7 @@ export class NcBlockMemberDescriptor extends BaseType
             new NcFieldDescriptor("role", "NcString", false, false, null, "Role of member in its containing block"),
             new NcFieldDescriptor("oid", "NcOid", false, false, null, "OID of member"),
             new NcFieldDescriptor("constantOid", "NcBoolean", false, false, null, "TRUE iff member's OID is hardwired into device"),
-            new NcFieldDescriptor("identity", "NcClassIdentity", false, false, null, "Class ID & version of member"),
+            new NcFieldDescriptor("classId", "NcClassId", false, false, null, "Class ID"),
             new NcFieldDescriptor("userLabel", "NcString", true, false, null, "User label"),
             new NcFieldDescriptor("owner", "NcOid", false, false, null, "Containing block's OID")
         ], null, null, "Descriptor which is specific to a block member which is not a block");
@@ -547,34 +521,33 @@ export class NcBlockDescriptor extends NcBlockMemberDescriptor
         role: string,
         oid: number,
         constantOid: boolean,
-        identity: NcClassIdentity,
+        classId: number[],
         userLabel: string | null,
         owner: number | null,
         description: string,
         constraints: NcPropertyConstraints | null)
     {
-        super(role, oid, constantOid, identity, userLabel, owner, description, constraints);
+        super(role, oid, constantOid, classId, userLabel, owner, description, constraints);
 
         this.blockSpecId = blockSpecId;
-        this.oid = oid;
-        this.constantOid = constantOid;
-        this.identity = identity;
-        this.userLabel = userLabel;
-        this.owner = owner;
-        this.description = description;
     }
 
     public static override GetTypeDescriptor(includeInherited: boolean): NcDatatypeDescriptor
     {
-        return new NcDatatypeDescriptorStruct("NcBlockDescriptor", [
-            new NcFieldDescriptor("role", "NcString", false, false, null, "Role of member in its containing block"),
-            new NcFieldDescriptor("oid", "NcOid", false, false, null, "OID of member"),
-            new NcFieldDescriptor("constantOid", "NcBoolean", false, false, null, "TRUE iff member's OID is hardwired into device"),
-            new NcFieldDescriptor("identity", "NcClassIdentity", false, false, null, "Class ID & version of member"),
-            new NcFieldDescriptor("userLabel", "NcString", true, false, null, "User label"),
-            new NcFieldDescriptor("owner", "NcOid", false, false, null, "Containing block's OID"),
+        let currentClassDescriptor = new NcDatatypeDescriptorStruct("NcBlockDescriptor", [
             new NcFieldDescriptor("blockSpecId", "NcString", false, false, null, "ID of BlockSpec this block implements")
         ], "NcBlockMemberDescriptor", null, "Descriptor which is specific to a block");
+
+        if(includeInherited)
+        {
+            let baseDescriptor = super.GetTypeDescriptor(includeInherited);
+
+            let baseDescriptorStruct = baseDescriptor as NcDatatypeDescriptorStruct;
+            if(baseDescriptorStruct)
+                currentClassDescriptor.fields = currentClassDescriptor.fields.concat(baseDescriptorStruct.fields);
+        }
+
+        return currentClassDescriptor;
     }
 
     public ToJson()
@@ -592,6 +565,7 @@ export class NcPropertyDescriptor extends NcDescriptor
     public isPersistent: boolean;
     public isNullable: boolean;
     public isSequence: boolean;
+    public isDeprecated: boolean;
     public constraints: NcParameterConstraints | null;
 
     constructor(
@@ -603,7 +577,8 @@ export class NcPropertyDescriptor extends NcDescriptor
         isNullable: boolean,
         isSequence: boolean,
         constraints: NcParameterConstraints | null,
-        description: string)
+        description: string,
+        isDeprecated: boolean = false)
     {
         super(description);
 
@@ -615,6 +590,7 @@ export class NcPropertyDescriptor extends NcDescriptor
         this.isNullable = isNullable;
         this.isSequence = isSequence;
         this.constraints = constraints;
+        this.isDeprecated = isDeprecated
     }
 
     public ToJson()
@@ -786,13 +762,15 @@ export class NcMethodDescriptor extends NcDescriptor
     public name: string;
     public resultDatatype: string;
     public parameters: NcParameterDescriptor[];
+    public isDeprecated: boolean;
 
     constructor(
         id: NcElementId,
         name: string,
         resultDatatype: string,
         parameters: NcParameterDescriptor[],
-        description: string)
+        description: string,
+        isDeprecated: boolean = false)
     {
         super(description);
 
@@ -800,6 +778,7 @@ export class NcMethodDescriptor extends NcDescriptor
         this.name = name;
         this.resultDatatype = resultDatatype;
         this.parameters = parameters;
+        this.isDeprecated = isDeprecated;
     }
 
     public ToJson()
@@ -813,18 +792,21 @@ export class NcEventDescriptor extends NcDescriptor
     public id: NcElementId;
     public name: string;
     public eventDatatype: string;
+    public isDeprecated: boolean;
 
     constructor(
         id: NcElementId,
         name: string,
         eventDatatype: string,
-        description: string)
+        description: string,
+        isDeprecated: boolean = false)
     {
         super(description);
 
         this.id = id;
         this.name = name;
         this.eventDatatype = eventDatatype;
+        this.isDeprecated = isDeprecated;
     }
 
     public ToJson()
@@ -835,7 +817,7 @@ export class NcEventDescriptor extends NcDescriptor
 
 export class NcClassDescriptor extends NcDescriptor
 {
-    public identity: NcClassIdentity;
+    public identity: number[];
     public name: string;
     public fixedRole: string | null;
     public properties: NcPropertyDescriptor[];
@@ -844,7 +826,7 @@ export class NcClassDescriptor extends NcDescriptor
 
     constructor(
         description: string,
-        identity: NcClassIdentity,
+        identity: number[],
         name: string,
         fixedRole: string | null,
         properties: NcPropertyDescriptor[],

--- a/code/src/NCModel/Core.ts
+++ b/code/src/NCModel/Core.ts
@@ -599,7 +599,7 @@ export class NcPropertyDescriptor extends NcDescriptor
     }
 }
 
-export class NcPropertyConstraints
+export class NcPropertyConstraints extends BaseType
 {
     public path: string[] | null;
     public propertyId: NcElementId;
@@ -610,9 +610,20 @@ export class NcPropertyConstraints
         propertyId: NcElementId,
         value: any | null)
     {
+        super();
+
         this.path = path;
         this.propertyId = propertyId;
         this.value = value;
+    }
+
+    public static override GetTypeDescriptor(includeInherited: boolean): NcDatatypeDescriptor
+    {
+        return new NcDatatypeDescriptorStruct("NcPropertyConstraints", [
+            new NcFieldDescriptor("path", "NcRolePath", true, false, null, "relative path to member (null means current member)"),
+            new NcFieldDescriptor("propertyId", "NcPropertyId", false, false, null, "ID of property being constrained"),
+            new NcFieldDescriptor("defaultValue", null, true, false, null, "optional default value")
+        ], null, null, "Property constraints class");
     }
 
     public ToJson()
@@ -642,6 +653,26 @@ export class NcPropertyConstraintsNumber extends NcPropertyConstraints
         this.step = step;
     }
 
+    public static override GetTypeDescriptor(includeInherited: boolean): NcDatatypeDescriptor
+    {
+        let currentClassDescriptor = new NcDatatypeDescriptorStruct("NcPropertyConstraintsNumber", [
+            new NcFieldDescriptor("maximum", null, true, false, null, "optional maximum"),
+            new NcFieldDescriptor("minimum", null, true, false, null, "optional minimum"),
+            new NcFieldDescriptor("step", null, true, false, null, "optional step"),
+        ], null, null, "Number property constraints class");
+
+        if(includeInherited)
+        {
+            let baseDescriptor = super.GetTypeDescriptor(includeInherited);
+
+            let baseDescriptorStruct = baseDescriptor as NcDatatypeDescriptorStruct;
+            if(baseDescriptorStruct)
+                currentClassDescriptor.fields = currentClassDescriptor.fields.concat(baseDescriptorStruct.fields);
+        }
+
+        return currentClassDescriptor;
+    }
+
     public ToJson()
     {
         return JSON.stringify(this, jsonIgnoreReplacer);
@@ -664,6 +695,25 @@ export class NcPropertyConstraintsString extends NcPropertyConstraints
         
         this.maxCharacters = maxCharacters;
         this.pattern = pattern;
+    }
+
+    public static override GetTypeDescriptor(includeInherited: boolean): NcDatatypeDescriptor
+    {
+        let currentClassDescriptor = new NcDatatypeDescriptorStruct("NcPropertyConstraintsString", [
+            new NcFieldDescriptor("maxCharacters", "NcUint32", true, false, null, "maximum characters allowed"),
+            new NcFieldDescriptor("pattern", "NcRegex", true, false, null, "regex pattern")
+        ], null, null, "String property constraints class");
+
+        if(includeInherited)
+        {
+            let baseDescriptor = super.GetTypeDescriptor(includeInherited);
+
+            let baseDescriptorStruct = baseDescriptor as NcDatatypeDescriptorStruct;
+            if(baseDescriptorStruct)
+                currentClassDescriptor.fields = currentClassDescriptor.fields.concat(baseDescriptorStruct.fields);
+        }
+
+        return currentClassDescriptor;
     }
 
     public ToJson()

--- a/code/src/NCModel/Features.ts
+++ b/code/src/NCModel/Features.ts
@@ -6,7 +6,6 @@ import {
     BaseType,
     myIdDecorator,
     NcClassDescriptor,
-    NcClassIdentity,
     NcDatatypeDescriptor,
     NcDatatypeDescriptorStruct,
     NcElementId,
@@ -19,19 +18,16 @@ import {
     NcParameterDescriptor,
     NcPort,
     NcPropertyChangeType,
+    NcPropertyConstraints,
     NcPropertyDescriptor,
     NcTouchpoint } from './Core';
 
 export abstract class NcWorker extends NcObject
 {
     public static staticClassID: number[] = [ 1, 2 ];
-    public static staticClassVersion: string = "1.0.0";
 
     @myIdDecorator('1p1')
     public override classID: number[] = NcWorker.staticClassID;
-
-    @myIdDecorator('1p2')
-    public override classVersion: string = NcWorker.staticClassVersion;
 
     @myIdDecorator('2p1')
     public enabled: boolean;
@@ -43,11 +39,12 @@ export abstract class NcWorker extends NcObject
         role: string,
         userLabel: string,
         touchpoints: NcTouchpoint[],
+        runtimePropertyConstraints: NcPropertyConstraints[] | null,
         enabled: boolean,
         description: string,
         notificationContext: INotificationContext)
     {
-        super(oid, constantOid, owner, role, userLabel, touchpoints, description, notificationContext);
+        super(oid, constantOid, owner, role, userLabel, touchpoints, runtimePropertyConstraints, description, notificationContext);
 
         this.enabled = enabled;
     }
@@ -93,7 +90,7 @@ export abstract class NcWorker extends NcObject
     public static override GetClassDescriptor(includeInherited: boolean): NcClassDescriptor 
     {
         let currentClassDescriptor = new NcClassDescriptor(`${NcWorker.name} class descriptor`,
-            new NcClassIdentity(NcWorker.staticClassID, NcWorker.staticClassVersion), NcWorker.name, null,
+            NcWorker.staticClassID, NcWorker.name, null,
             [
                 new NcPropertyDescriptor(new NcElementId(2, 1), "enabled", "NcBoolean", false, true, false, false, null, "TRUE iff worker is enabled")
             ],
@@ -117,13 +114,9 @@ export abstract class NcWorker extends NcObject
 export abstract class NcSignalWorker extends NcWorker
 {
     public static staticClassID: number[] = [ 1, 2, 1 ];
-    public static staticClassVersion: string = "1.0.0";
 
     @myIdDecorator('1p1')
     public override classID: number[] = NcSignalWorker.staticClassID;
-
-    @myIdDecorator('1p2')
-    public override classVersion: string = NcSignalWorker.staticClassVersion;
 
     @myIdDecorator('3p1')
     public ports: NcPort[] | null;
@@ -138,13 +131,14 @@ export abstract class NcSignalWorker extends NcWorker
         role: string,
         userLabel: string,
         touchpoints: NcTouchpoint[],
+        runtimePropertyConstraints: NcPropertyConstraints[] | null,
         enabled: boolean,
         ports: NcPort[] | null,
         latency: number | null,
         description: string,
         notificationContext: INotificationContext)
     {
-        super(oid, constantOid, owner, role, userLabel, touchpoints, enabled, description, notificationContext);
+        super(oid, constantOid, owner, role, userLabel, touchpoints, runtimePropertyConstraints, enabled, description, notificationContext);
 
         this.ports = ports;
         this.latency = latency;
@@ -194,7 +188,7 @@ export abstract class NcSignalWorker extends NcWorker
     public static override GetClassDescriptor(includeInherited: boolean): NcClassDescriptor 
     {
         let currentClassDescriptor = new NcClassDescriptor(`${NcSignalWorker.name} class descriptor`,
-            new NcClassIdentity(NcSignalWorker.staticClassID, NcSignalWorker.staticClassVersion), NcSignalWorker.name, null,
+            NcSignalWorker.staticClassID, NcSignalWorker.name, null,
             [
                 new NcPropertyDescriptor(new NcElementId(3, 1), "ports", "NcPort", false, true, false, true, null, "The worker's signal ports"),
                 new NcPropertyDescriptor(new NcElementId(3, 2), "latency", "NcTimeInterval", true, true, true, false, null, "Processing latency of this object (null if not defined)")
@@ -219,13 +213,9 @@ export abstract class NcSignalWorker extends NcWorker
 export abstract class NcActuator extends NcSignalWorker
 {
     public static staticClassID: number[] = [ 1, 2, 1, 1 ];
-    public static staticClassVersion: string = "1.0.0";
 
     @myIdDecorator('1p1')
     public override classID: number[] = NcActuator.staticClassID;
-
-    @myIdDecorator('1p2')
-    public override classVersion: string = NcActuator.staticClassVersion;
 
     public constructor(
         oid: number,
@@ -234,19 +224,20 @@ export abstract class NcActuator extends NcSignalWorker
         role: string,
         userLabel: string,
         touchpoints: NcTouchpoint[],
+        runtimePropertyConstraints: NcPropertyConstraints[] | null,
         enabled: boolean,
         ports: NcPort[] | null,
         latency: number | null,
         description: string,
         notificationContext: INotificationContext)
     {
-        super(oid, constantOid, owner, role, userLabel, touchpoints, enabled, ports, latency, description, notificationContext);
+        super(oid, constantOid, owner, role, userLabel, touchpoints, runtimePropertyConstraints, enabled, ports, latency, description, notificationContext);
     }
 
     public static override GetClassDescriptor(includeInherited: boolean): NcClassDescriptor 
     {
         let currentClassDescriptor = new NcClassDescriptor(`${NcActuator.name} class descriptor`,
-            new NcClassIdentity(NcActuator.staticClassID, NcActuator.staticClassVersion), NcActuator.name, null,
+            NcActuator.staticClassID, NcActuator.name, null,
         [], [], []);
 
         if(includeInherited)
@@ -265,13 +256,9 @@ export abstract class NcActuator extends NcSignalWorker
 export class NcGain extends NcActuator
 {
     public static staticClassID: number[] = [ 1, 2, 1, 1, 1 ];
-    public static staticClassVersion: string = "1.0.0";
 
     @myIdDecorator('1p1')
     public override classID: number[] = NcGain.staticClassID;
-
-    @myIdDecorator('1p2')
-    public override classVersion: string = NcGain.staticClassVersion;
 
     @myIdDecorator('5p1')
     public gainValue: number;
@@ -283,6 +270,7 @@ export class NcGain extends NcActuator
         role: string,
         userLabel: string,
         touchpoints: NcTouchpoint[],
+        runtimePropertyConstraints: NcPropertyConstraints[] | null,
         enabled: boolean,
         ports: NcPort[] | null,
         latency: number | null,
@@ -290,7 +278,7 @@ export class NcGain extends NcActuator
         description: string,
         notificationContext: INotificationContext)
     {
-        super(oid, constantOid, owner, role, userLabel, touchpoints, enabled, ports, latency, description, notificationContext);
+        super(oid, constantOid, owner, role, userLabel, touchpoints, runtimePropertyConstraints, enabled, ports, latency, description, notificationContext);
 
         this.gainValue = gainValue;
     }
@@ -338,7 +326,7 @@ export class NcGain extends NcActuator
     public static override GetClassDescriptor(includeInherited: boolean): NcClassDescriptor 
     {
         let currentClassDescriptor = new NcClassDescriptor(`${NcGain.name} class descriptor`,
-            new NcClassIdentity(NcGain.staticClassID, NcGain.staticClassVersion), NcGain.name, null,
+            NcGain.staticClassID, NcGain.name, null,
             [
                 new NcPropertyDescriptor(new NcElementId(5, 1), "gainValue", "NcDB", false, false, false, false, null, "Gain value")
             ],
@@ -362,13 +350,9 @@ export class NcGain extends NcActuator
 export class NcIdentBeacon extends NcWorker
 {
     public static staticClassID: number[] = [ 1, 2, 2 ];
-    public static staticClassVersion: string = "1.0.0";
 
     @myIdDecorator('1p1')
     public override classID: number[] = NcIdentBeacon.staticClassID;
-
-    @myIdDecorator('1p2')
-    public override classVersion: string = NcIdentBeacon.staticClassVersion;
 
     @myIdDecorator('3p1')
     public active: boolean;
@@ -380,12 +364,13 @@ export class NcIdentBeacon extends NcWorker
         role: string,
         userLabel: string,
         touchpoints: NcTouchpoint[],
+        runtimePropertyConstraints: NcPropertyConstraints[] | null,
         enabled: boolean,
         active: boolean,
         description: string,
         notificationContext: INotificationContext)
     {
-        super(oid, constantOid, owner, role, userLabel, touchpoints, enabled, description, notificationContext);
+        super(oid, constantOid, owner, role, userLabel, touchpoints, runtimePropertyConstraints, enabled, description, notificationContext);
 
         this.active = active;
     }
@@ -433,7 +418,7 @@ export class NcIdentBeacon extends NcWorker
     public static override GetClassDescriptor(includeInherited: boolean): NcClassDescriptor 
     {
         let currentClassDescriptor = new NcClassDescriptor(`${NcIdentBeacon.name} class descriptor`,
-            new NcClassIdentity(NcIdentBeacon.staticClassID, NcIdentBeacon.staticClassVersion), NcIdentBeacon.name, null,
+            NcIdentBeacon.staticClassID, NcIdentBeacon.name, null,
             [
                 new NcPropertyDescriptor(new NcElementId(3, 1), "active", "NcBoolean", false, false, false, false, null, "Indicator active state")
             ],
@@ -502,13 +487,9 @@ export class NcReceiverStatus extends BaseType
 export class NcReceiverMonitor extends NcWorker
 {
     public static staticClassID: number[] = [ 1, 2, 3 ];
-    public static staticClassVersion: string = "1.0.0";
 
     @myIdDecorator('1p1')
     public override classID: number[] = NcReceiverMonitor.staticClassID;
-
-    @myIdDecorator('1p2')
-    public override classVersion: string = NcReceiverMonitor.staticClassVersion;
 
     @myIdDecorator('3p1')
     public connectionStatus: NcConnectionStatus;
@@ -529,11 +510,12 @@ export class NcReceiverMonitor extends NcWorker
         role: string,
         userLabel: string,
         touchpoints: NcTouchpoint[],
+        runtimePropertyConstraints: NcPropertyConstraints[] | null,
         enabled: boolean,
         description: string,
         notificationContext: INotificationContext)
     {
-        super(oid, constantOid, owner, role, userLabel, touchpoints, enabled, description, notificationContext);
+        super(oid, constantOid, owner, role, userLabel, touchpoints, runtimePropertyConstraints, enabled, description, notificationContext);
 
         this.connectionStatus = NcConnectionStatus.Undefined;
         this.connectionStatusMessage = null;
@@ -634,7 +616,7 @@ export class NcReceiverMonitor extends NcWorker
     public static override GetClassDescriptor(includeInherited: boolean): NcClassDescriptor 
     {
         let currentClassDescriptor = new NcClassDescriptor(`${NcReceiverMonitor.name} class descriptor`,
-            new NcClassIdentity(NcReceiverMonitor.staticClassID, NcReceiverMonitor.staticClassVersion), NcReceiverMonitor.name, null,
+            NcReceiverMonitor.staticClassID, NcReceiverMonitor.name, null,
             [
                 new NcPropertyDescriptor(new NcElementId(3, 1), "connectionStatus", "NcConnectionStatus", true, false, false, false, null, "Connection status property"),
                 new NcPropertyDescriptor(new NcElementId(3, 2), "connectionStatusMessage", "NcString", true, false, true, false, null, "Connection status message property"),
@@ -708,13 +690,9 @@ export class DemoDataType extends BaseType
 export class NcDemo extends NcWorker
 {
     public static staticClassID: number[] = [ 1, 2, 0, 1 ];
-    public static staticClassVersion: string = "1.0.0";
 
     @myIdDecorator('1p1')
     public override classID: number[] = NcDemo.staticClassID;
-
-    @myIdDecorator('1p2')
-    public override classVersion: string = NcDemo.staticClassVersion;
 
     @myIdDecorator('3p1')
     public enumProperty: NcDemoEnum;
@@ -762,11 +740,12 @@ export class NcDemo extends NcWorker
         role: string,
         userLabel: string,
         touchpoints: NcTouchpoint[],
+        runtimePropertyConstraints: NcPropertyConstraints[] | null,
         enabled: boolean,
         description: string,
         notificationContext: INotificationContext)
     {
-        super(oid, constantOid, owner, role, userLabel, touchpoints, enabled, description, notificationContext);
+        super(oid, constantOid, owner, role, userLabel, touchpoints, runtimePropertyConstraints, enabled, description, notificationContext);
 
         this.enumProperty = NcDemoEnum.Undefined;
         this.stringProperty = "test";
@@ -1360,7 +1339,7 @@ export class NcDemo extends NcWorker
     public static override GetClassDescriptor(includeInherited: boolean): NcClassDescriptor 
     {
         let currentClassDescriptor = new NcClassDescriptor(`${NcDemo.name} class descriptor`,
-            new NcClassIdentity(NcDemo.staticClassID, NcDemo.staticClassVersion), NcDemo.name, null,
+            NcDemo.staticClassID, NcDemo.name, null,
             [
                 new NcPropertyDescriptor(new NcElementId(3, 1), "enumProperty", "NcDemoEnum", false, false, false, false, null, "Demo enum property"),
                 new NcPropertyDescriptor(new NcElementId(3, 2), "stringProperty", "NcString", false, false, false, false, new NcParameterConstraintsString(10, null),

--- a/code/src/NCModel/Managers.ts
+++ b/code/src/NCModel/Managers.ts
@@ -25,6 +25,8 @@ import {
     NcPortReference,
     NcPropertyChangeType,
     NcPropertyConstraints,
+    NcPropertyConstraintsNumber,
+    NcPropertyConstraintsString,
     NcPropertyDescriptor,
     NcSignalPath,
     NcTouchpoint,
@@ -706,7 +708,11 @@ export class NcClassManager extends NcManager
                 new NcEnumItemDescriptor("Beta", 2, "Beta option"),
                 new NcEnumItemDescriptor("Gamma", 3, "Gamma option")
             ], null, "Demonstration enum data type"),
-            'DemoDataType': DemoDataType.GetTypeDescriptor(false)
+            'DemoDataType': DemoDataType.GetTypeDescriptor(false),
+            'NcRegex': new NcDatatypeDescriptorTypeDef("NcRegex", "NcString", false, null, "Regex pattern"),
+            'NcPropertyConstraints': NcPropertyConstraints.GetTypeDescriptor(false),
+            'NcPropertyConstraintsNumber': NcPropertyConstraintsNumber.GetTypeDescriptor(false),
+            'NcPropertyConstraintsString': NcPropertyConstraintsString.GetTypeDescriptor(false),
         };
 
         return register;
@@ -731,6 +737,9 @@ export class NcClassManager extends NcManager
             case 'NcTouchpointNmos': return NcTouchpointNmos.GetTypeDescriptor(true);
             case 'NcTouchpointResourceNmos': return NcTouchpointResourceNmos.GetTypeDescriptor(true);
             case 'DemoDataType': return DemoDataType.GetTypeDescriptor(true);
+            case 'NcPropertyConstraints': return NcPropertyConstraints.GetTypeDescriptor(true);
+            case 'NcPropertyConstraintsNumber': return NcPropertyConstraintsNumber.GetTypeDescriptor(true);
+            case 'NcPropertyConstraintsString': return NcPropertyConstraintsString.GetTypeDescriptor(true);
             default: return this.dataTypesRegister[name];
         }
     }

--- a/code/src/NCModel/Managers.ts
+++ b/code/src/NCModel/Managers.ts
@@ -9,7 +9,6 @@ import {
     myIdDecorator,
     NcBlockMemberDescriptor,
     NcClassDescriptor,
-    NcClassIdentity,
     NcDatatypeDescriptor,
     NcDatatypeDescriptorEnum,
     NcDatatypeDescriptorPrimitive,
@@ -25,6 +24,7 @@ import {
     NcPort,
     NcPortReference,
     NcPropertyChangeType,
+    NcPropertyConstraints,
     NcPropertyDescriptor,
     NcSignalPath,
     NcTouchpoint,
@@ -36,13 +36,9 @@ import { DemoDataType, NcActuator, NcDemo, NcGain, NcIdentBeacon, NcReceiverMoni
 export abstract class NcManager extends NcObject
 {
     public static staticClassID: number[] = [ 1, 3 ];
-    public static staticClassVersion: string = "1.0.0";
 
     @myIdDecorator('1p1')
     public override classID: number[] = NcManager.staticClassID;
-
-    @myIdDecorator('1p2')
-    public override classVersion: string = NcManager.staticClassVersion;
 
     public constructor(
         oid: number,
@@ -51,16 +47,17 @@ export abstract class NcManager extends NcObject
         role: string,
         userLabel: string,
         touchpoints: NcTouchpoint[] | null,
+        runtimePropertyConstraints: NcPropertyConstraints[] | null,
         description: string,
         notificationContext: INotificationContext)
     {
-        super(oid, constantOid, owner, role, userLabel, touchpoints, description, notificationContext);
+        super(oid, constantOid, owner, role, userLabel, touchpoints, runtimePropertyConstraints, description, notificationContext);
     }
 
     public static override GetClassDescriptor(includeInherited: boolean): NcClassDescriptor
     {
         let currentClassDescriptor = new NcClassDescriptor(`${NcManager.name} class descriptor`,
-            new NcClassIdentity(NcManager.staticClassID, NcManager.staticClassVersion), NcManager.name, null,
+            NcManager.staticClassID, NcManager.name, null,
         [], [], []);
 
         if(includeInherited)
@@ -204,13 +201,9 @@ export enum NcResetCause
 export class NcDeviceManager extends NcManager
 {
     public static staticClassID: number[] = [ 1, 3, 1 ];
-    public static staticClassVersion: string = "1.0.0";
 
     @myIdDecorator('1p1')
     public override classID: number[] = NcDeviceManager.staticClassID;
-
-    @myIdDecorator('1p2')
-    public override classVersion: string = NcDeviceManager.staticClassVersion;
 
     @myIdDecorator('3p1')
     public ncVersion: string = "1.0.0";
@@ -250,10 +243,11 @@ export class NcDeviceManager extends NcManager
         owner: number | null,
         userLabel: string,
         touchpoints: NcTouchpoint[] | null,
+        runtimePropertyConstraints: NcPropertyConstraints[] | null,
         description: string,
         notificationContext: INotificationContext)
     {
-        super(oid, constantOid, owner, NcDeviceManager.staticRole, userLabel, touchpoints, description, notificationContext);
+        super(oid, constantOid, owner, NcDeviceManager.staticRole, userLabel, touchpoints, runtimePropertyConstraints, description, notificationContext);
 
         this.manufacturer = new NcManufacturer("Mock manufacturer", "https://specs.amwa.tv/nmos/");
         this.product = new NcProduct("Mock device", "mock-001", "1.0.0", "Mock brand", "2dcd15f6-aecc-4f01-bf66-b1044c677ef4", "Mock device for testing and prototyping");
@@ -343,7 +337,7 @@ export class NcDeviceManager extends NcManager
     public static override GetClassDescriptor(includeInherited: boolean): NcClassDescriptor
     {
         let currentClassDescriptor = new NcClassDescriptor(`${NcDeviceManager.name} class descriptor`,
-            new NcClassIdentity(NcDeviceManager.staticClassID, NcDeviceManager.staticClassVersion), NcDeviceManager.name, NcDeviceManager.staticRole,
+            NcDeviceManager.staticClassID, NcDeviceManager.name, NcDeviceManager.staticRole,
             [
                 new NcPropertyDescriptor(new NcElementId(3, 1), "ncVersion", "NcVersionCode", true, true, false, false, null, "Version of nc this dev uses"),
                 new NcPropertyDescriptor(new NcElementId(3, 2), "manufacturer", "NcManufacturer", true, true, false, false, null, "Manufacturer descriptor"),
@@ -376,13 +370,9 @@ export class NcDeviceManager extends NcManager
 export class NcClassManager extends NcManager
 {
     public static staticClassID: number[] = [ 1, 3, 2 ];
-    public static staticClassVersion: string = "1.0.0";
 
     @myIdDecorator('1p1')
     public override classID: number[] = NcClassManager.staticClassID;
-
-    @myIdDecorator('1p2')
-    public override classVersion: string = NcClassManager.staticClassVersion;
 
     @myIdDecorator('3p1')
     public controlClasses: NcClassDescriptor[];
@@ -401,10 +391,11 @@ export class NcClassManager extends NcManager
         owner: number | null,
         userLabel: string,
         touchpoints: NcTouchpoint[] | null,
+        runtimePropertyConstraints: NcPropertyConstraints[] | null,
         description: string,
         notificationContext: INotificationContext)
     {
-        super(oid, constantOid, owner, NcClassManager.staticRole, userLabel, touchpoints, description, notificationContext);
+        super(oid, constantOid, owner, NcClassManager.staticRole, userLabel, touchpoints, runtimePropertyConstraints, description, notificationContext);
 
         this.controlClassesRegister = this.GenerateClassDescriptors();
         this.controlClasses = Object.values(this.controlClassesRegister);
@@ -448,7 +439,7 @@ export class NcClassManager extends NcManager
                         {
                             if('includeInherited' in args)
                             {
-                                let identity = args['identity'] as NcClassIdentity;
+                                let identity = args['identity'] as number[];
                                 let includeInherited = args['includeInherited'] as boolean;
 
                                 if(includeInherited)
@@ -517,14 +508,14 @@ export class NcClassManager extends NcManager
     public static override GetClassDescriptor(includeInherited: boolean): NcClassDescriptor 
     {
         let currentClassDescriptor = new NcClassDescriptor(`${NcClassManager.name} class descriptor`,
-            new NcClassIdentity(NcClassManager.staticClassID, NcClassManager.staticClassVersion), NcClassManager.name, NcClassManager.staticRole,
+            NcClassManager.staticClassID, NcClassManager.name, NcClassManager.staticRole,
             [ 
                 new NcPropertyDescriptor(new NcElementId(3, 1), "controlClasses", "NcClassDescriptor", true, true, false, true, null, "Descriptions of all control classes in the device"),
                 new NcPropertyDescriptor(new NcElementId(3, 2), "datatypes", "NcDatatypeDescriptor", true, true, false, true, null, "Descriptions of all data types in the device")
             ],
             [ 
                 new NcMethodDescriptor(new NcElementId(3, 1), "GetControlClass", "NcMethodResultClassDescriptor", [
-                    new NcParameterDescriptor("identity", "NcClassIdentity", false, false, null, "class ID & version")
+                    new NcParameterDescriptor("identity", "NcClassId", false, false, null, "class ID")
                 ], "Get a single class descriptor"),
                 new NcMethodDescriptor(new NcElementId(3, 2), "GetDatatype", "NcMethodResultDatatypeDescriptor", [
                     new NcParameterDescriptor("name", "NcName", false, false, null, "name of datatype")
@@ -565,9 +556,9 @@ export class NcClassManager extends NcManager
         return register;
     }
 
-    private GenerateClassDescriptorWithInheritedElements(identity: NcClassIdentity) : NcClassDescriptor | null
+    private GenerateClassDescriptorWithInheritedElements(identity: number[]) : NcClassDescriptor | null
     {
-        let key: string = identity.id.join('.');
+        let key: string = identity.join('.');
 
         switch (key)
         {
@@ -600,8 +591,7 @@ export class NcClassManager extends NcManager
             'NcFloat32': new NcDatatypeDescriptorPrimitive("NcFloat32", null, "unrestrictedfloat"),
             'NcFloat64': new NcDatatypeDescriptorPrimitive("NcFloat64", null, "unrestricteddouble"),
             'NcString': new NcDatatypeDescriptorPrimitive("NcString", null, "UTF-8 string"),
-            'NcClassId': new NcDatatypeDescriptorTypeDef("NcClassId", "NcClassIdField", true, null, "Sequence of class ID fields."),
-            'NcClassIdField': new NcDatatypeDescriptorTypeDef("NcClassIdField", "NcInt32", false, null, "Class ID field. Either a definition index or an authority key."),
+            'NcClassId': new NcDatatypeDescriptorTypeDef("NcClassId", "NcInt32", true, null, "Sequence of class ID fields."),
             'NcVersionCode': new NcDatatypeDescriptorTypeDef("NcVersionCode", "NcString", false, null, "Version code in semantic versioning format"),
             'NcUri': new NcDatatypeDescriptorTypeDef("NcUri", "NcString", false, null, "Uniform resource identifier"),
             'NcOrganizationId': new NcDatatypeDescriptorTypeDef("NcOrganizationId", "NcInt32", true, null, "Unique 24-bit organization ID"),
@@ -641,6 +631,8 @@ export class NcClassManager extends NcManager
             'NcPropertyChangedEventData': NcPropertyChangedEventData.GetTypeDescriptor(false),
             'NcMethodStatus': new NcDatatypeDescriptorEnum("NcMethodStatus", [
                 new NcEnumItemDescriptor("Ok", 200, "Method call was successful"),
+                new NcEnumItemDescriptor("PropertyDeprecated", 298, "Method call was successful but targeted property is deprecated"),
+                new NcEnumItemDescriptor("MethodDeprecated", 299, "Method call was successful but method is deprecated"),
                 new NcEnumItemDescriptor("BadCommandFormat", 400, "Badly-formed command"),
                 new NcEnumItemDescriptor("Unauthorized", 401, "Client is not authorized"),
                 new NcEnumItemDescriptor("BadOid", 404, "Command addresses a nonexistent object"),
@@ -671,7 +663,6 @@ export class NcClassManager extends NcManager
                 new NcFieldDescriptor("errorMessage", "NcString", true, false, null, "Optional error message"),
                 new NcFieldDescriptor("value", "NcId", false, false, null, "NcId method result value")
             ], "NcMethodResult", null, "Method result containing an NcId value"),
-            'NcClassIdentity': NcClassIdentity.GetTypeDescriptor(false),
             'NcBlockMemberDescriptor': NcBlockMemberDescriptor.GetTypeDescriptor(false),
             'NcMethodResultBlockMemberDescriptors': new NcDatatypeDescriptorStruct("NcMethodResultBlockMemberDescriptors", [
                 new NcFieldDescriptor("status", "NcMethodStatus", false, false, null, "Status for the invoked method"),
@@ -730,7 +721,6 @@ export class NcClassManager extends NcManager
             case 'NcDeviceOperationalState': return NcDeviceOperationalState.GetTypeDescriptor(true);
             case 'NcElementId': return NcElementId.GetTypeDescriptor(true);
             case 'NcPropertyChangedEventData': return NcPropertyChangedEventData.GetTypeDescriptor(true);
-            case 'NcClassIdentity': return NcClassIdentity.GetTypeDescriptor(true);
             case 'NcBlockMemberDescriptor': return NcBlockMemberDescriptor.GetTypeDescriptor(true);
             case 'NcReceiverStatus': return NcReceiverStatus.GetTypeDescriptor(true);
             case 'NcPort': return NcPort.GetTypeDescriptor(true);
@@ -745,13 +735,13 @@ export class NcClassManager extends NcManager
         }
     }
 
-    private GetClassDescriptor(identity: NcClassIdentity, includeInherited: boolean) : NcClassDescriptor | null
+    private GetClassDescriptor(identity: number[], includeInherited: boolean) : NcClassDescriptor | null
     {
         if(includeInherited)
             return this.GenerateClassDescriptorWithInheritedElements(identity);
         else
         {
-            let key: string = identity.id.join('.');
+            let key: string = identity.join('.');
 
             return this.controlClassesRegister[key];
         }

--- a/code/src/NCProtocol/Commands.ts
+++ b/code/src/NCProtocol/Commands.ts
@@ -69,7 +69,7 @@ export class CommandResponseWithValue extends CommandResponseNoValue
     }
 }
 
-export class ProtoCommand extends ProtocolWrapper
+export class ProtocolCommand extends ProtocolWrapper
 {
     public commands: CommandMsg[];
 
@@ -87,7 +87,7 @@ export class ProtoCommand extends ProtocolWrapper
     }
 }
 
-export class ProtoCommandResponse extends ProtocolWrapper
+export class ProtocolCommandResponse extends ProtocolWrapper
 {
     public responses: CommandResponseNoValue[];
 
@@ -110,7 +110,7 @@ export class ProtoCommandResponse extends ProtocolWrapper
     }
 }
 
-export class ProtoSubscription extends ProtocolWrapper
+export class ProtocolSubscription extends ProtocolWrapper
 {
     public subscriptions: number[];
 
@@ -128,7 +128,7 @@ export class ProtoSubscription extends ProtocolWrapper
     }
 }
 
-export class ProtoSubscriptionResponse extends ProtocolWrapper
+export class ProtocolSubscriptionResponse extends ProtocolWrapper
 {
     public subscriptions: number[];
 
@@ -146,7 +146,7 @@ export class ProtoSubscriptionResponse extends ProtocolWrapper
     }
 }
 
-export class ProtoError extends ProtocolWrapper
+export class ProtocolError extends ProtocolWrapper
 {
     public status: NcMethodStatus;
 

--- a/code/src/NCProtocol/Notifications.ts
+++ b/code/src/NCProtocol/Notifications.ts
@@ -62,7 +62,7 @@ export class NcNotification
     }
 }
 
-export class ProtoNotification extends ProtocolWrapper
+export class ProtocolNotification extends ProtocolWrapper
 {
     public notifications: NcNotification[];
 

--- a/code/src/NCProtocol/Notifications.ts
+++ b/code/src/NCProtocol/Notifications.ts
@@ -1,4 +1,3 @@
-import exp from 'constants';
 import { jsonIgnoreReplacer, jsonIgnore } from 'json-ignore';
 import { BaseType, NcDatatypeDescriptor, NcDatatypeDescriptorStruct, NcElementId, NcFieldDescriptor, NcPropertyChangeType } from '../NCModel/Core';
 import { MessageType, ProtocolWrapper } from './Core';

--- a/code/src/RegistrationClient.ts
+++ b/code/src/RegistrationClient.ts
@@ -11,18 +11,26 @@ export class RegistrationClient
     public registry_port: string;
     public node_id: string | null;
 
+    public work_without_registry: boolean;
+
     public constructor(
         registry_address: string,
-        registry_port: string)
+        registry_port: string,
+        work_without_registry: boolean)
     {
         this.registry_address = registry_address;
         this.registry_port = registry_port;
         this.node_id = null;
+
+        this.work_without_registry = work_without_registry;
     }
 
     StartHeatbeats(node_id: string)
     {
         this.node_id = node_id;
+
+        if(this.work_without_registry)
+            return;
 
         this.SendHeartbeat(this.node_id);
 
@@ -35,6 +43,9 @@ export class RegistrationClient
     {
         try 
         {
+            if(this.work_without_registry)
+                return null;
+
             console.log(`RegistrationClient - RegisterOrUpdateResource(resourceType:${resourceType})`);
 
             let payload = new RegisterResourceMsg(resourceType, resource);

--- a/code/src/Server.ts
+++ b/code/src/Server.ts
@@ -15,7 +15,7 @@ import { NcBlock, RootBlock } from './NCModel/Blocks';
 import { NcClassManager, NcDeviceManager } from './NCModel/Managers';
 import { NcIoDirection, NcMethodStatus, NcPort, NcPortReference, NcSignalPath, NcTouchpointNmos, NcTouchpointResourceNmos } from './NCModel/Core';
 import { NcDemo, NcGain, NcIdentBeacon, NcReceiverMonitor } from './NCModel/Features';
-import { ProtoError, ProtoSubscription } from './NCProtocol/Commands';
+import { ProtocolError, ProtocolSubscription } from './NCProtocol/Commands';
 import { MessageType, ProtocolWrapper } from './NCProtocol/Core';
 
 export interface WebSocketConnection extends WebSocket {
@@ -266,7 +266,7 @@ try
                             break;
                             case MessageType.Subscription:
                             {
-                                let message = JSON.parse(msg) as ProtoSubscription;
+                                let message = JSON.parse(msg) as ProtocolSubscription;
                                 sessionManager.ModifySubscription(extWs, message);
                                 isMessageValid = true;
                             }
@@ -302,7 +302,7 @@ try
             if(isMessageValid == false)
             {
                 console.log(errorMessage);
-                let error = new ProtoError(status, errorMessage);
+                let error = new ProtocolError(status, errorMessage);
                 extWs.send(error.ToJson());
             }
         });

--- a/code/src/Server.ts
+++ b/code/src/Server.ts
@@ -67,6 +67,7 @@ try
         1,
         'Device manager',
         null,
+        null,
         "The device manager offers information about the product this device is representing",
         sessionManager);
 
@@ -75,6 +76,7 @@ try
         true,
         1,
         'Class manager',
+        null,
         null,
         "The class manager offers access to control class and data type descriptors",
         sessionManager);
@@ -86,6 +88,7 @@ try
         'ReceiverMonitor_01',
         'Receiver monitor 01',
         [ new NcTouchpointNmos('x-nmos', new NcTouchpointResourceNmos('receiver', myVideoReceiver.id)) ],
+        null,
         true,
         "Receiver monitor worker",
         sessionManager);
@@ -99,6 +102,7 @@ try
         'DemoClass',
         'Demo class',
         [],
+        null,
         true,
         "Demo control class",
         sessionManager);
@@ -111,6 +115,7 @@ try
         'channel-gain',
         'Channel gain',
         null,
+        null,
         true,
         null,
         null,
@@ -119,11 +124,11 @@ try
         null,
         false,
         [
-            new NcGain(22, true, 21, "left-gain", "Left gain", [], true, [
+            new NcGain(22, true, 21, "left-gain", "Left gain", [], null, true, [
                 new NcPort('input_1', NcIoDirection.Input, null),
                 new NcPort('output_1', NcIoDirection.Output, null),
             ], null, 0, "Left channel gain", sessionManager),
-            new NcGain(23, true, 21, "right-gain", "Right gain", [], true, [
+            new NcGain(23, true, 21, "right-gain", "Right gain", [], null, true, [
                 new NcPort('input_1', NcIoDirection.Input, null),
                 new NcPort('output_1', NcIoDirection.Output, null),
             ], null, 0, "Right channel gain", sessionManager)
@@ -151,6 +156,7 @@ try
             'stereo-gain',
             'Stereo gain',
             null,
+            null,
             true,
             null,
             null,
@@ -160,7 +166,7 @@ try
             false,
             [
                 channelGainBlock,
-                new NcGain(24, true, 31, "master-gain", "Master gain", [], true, [
+                new NcGain(24, true, 31, "master-gain", "Master gain", [], null, true, [
                     new NcPort('input_1', NcIoDirection.Input, null),
                     new NcPort('input_2', NcIoDirection.Input, null),
                     new NcPort('output_1', NcIoDirection.Output, null),
@@ -184,7 +190,7 @@ try
             "Stereo gain block",
             sessionManager);
 
-    const identBeacon = new NcIdentBeacon(51, true, 1, "IdentBeacon", "Identification beacon", [], true, false, "Identification beacon", sessionManager);
+    const identBeacon = new NcIdentBeacon(51, true, 1, "IdentBeacon", "Identification beacon", [], null, true, false, "Identification beacon", sessionManager);
 
     const rootBlock = new RootBlock(
         1,
@@ -192,6 +198,7 @@ try
         null,
         'root',
         'Root',
+        null,
         null,
         true,
         "base-root",

--- a/code/src/Server.ts
+++ b/code/src/Server.ts
@@ -33,7 +33,7 @@ try
     console.log('App started');
     const config = new Configuration();
 
-    const registrationClient = new RegistrationClient(config.registry_address, config.registry_port);
+    const registrationClient = new RegistrationClient(config.registry_address, config.registry_port, config.work_without_registry);
 
     const myNode = new NmosNode(
         config.node_id,

--- a/code/src/SessionManager.ts
+++ b/code/src/SessionManager.ts
@@ -2,8 +2,8 @@ import { jsonIgnoreReplacer, jsonIgnore } from 'json-ignore';
 
 import { WebSocketConnection } from './Server';
 import { NcElementId, NcMethodStatus, NcPropertyChangeType } from './NCModel/Core';
-import { NcPropertyChangedEventData, NcNotification, ProtoNotification } from './NCProtocol/Notifications';
-import { ProtoError, ProtoSubscription, ProtoSubscriptionResponse } from './NCProtocol/Commands';
+import { NcPropertyChangedEventData, NcNotification, ProtocolNotification } from './NCProtocol/Notifications';
+import { ProtocolError, ProtocolSubscription, ProtocolSubscriptionResponse } from './NCProtocol/Commands';
 
 export interface INotificationContext
 {
@@ -22,7 +22,7 @@ export class SessionManager implements INotificationContext
         this.sessions = {};
     }
 
-    public ModifySubscription(socket: WebSocketConnection, subscription: ProtoSubscription)
+    public ModifySubscription(socket: WebSocketConnection, subscription: ProtocolSubscription)
     {
         if(subscription.subscriptions)
         {
@@ -35,7 +35,7 @@ export class SessionManager implements INotificationContext
                     sub.Subscribe(oid);
                 });
 
-                let response = new ProtoSubscriptionResponse(subscription.subscriptions);
+                let response = new ProtocolSubscriptionResponse(subscription.subscriptions);
                 socket.send(response.ToJson());
             }
         }
@@ -43,7 +43,7 @@ export class SessionManager implements INotificationContext
         {
             let errorMessage = `Invalid subscription message received.`
             console.log(errorMessage);
-            let error = new ProtoError(NcMethodStatus.BadCommandFormat, errorMessage);
+            let error = new ProtocolError(NcMethodStatus.BadCommandFormat, errorMessage);
             socket.send(error.ToJson());
         }
     }
@@ -58,7 +58,7 @@ export class SessionManager implements INotificationContext
             if(this.notifyWithoutSubscriptions || session.ShouldNotify(oid))
             {
                 session.socket.send(
-                    new ProtoNotification(
+                    new ProtocolNotification(
                         [ new NcNotification(oid, new NcElementId(1, 1), new NcPropertyChangedEventData(propertyId, changeType, value, sequenceItemIndex)) ]
                     ).ToJson());
             }


### PR DESCRIPTION
- removed class versions and NcClassIdentity
- added runtimePropertyConstraints to NcObject
- NcBlockMemberDescriptor property name is now classId and not identity
- add deprecation status isDeprecated to property, method and event descriptors
- add 2 new NcMethodStatus options (PropertyDeprecated and MethodDeprecated)