### PR TITLE
Update DeviceModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ These are the configuration keys which can be specified in the configuration fil
 * [AMWA IS-12 NMOS Control Protocol](https://specs.amwa.tv/is-12)
 * [MS-05-01 NMOS Control Architecture](https://specs.amwa.tv/ms-05-01)
 * [MS-05-02 NMOS Control Framework](https://specs.amwa.tv/ms-05-02)
-* [MS-05-03 NMOS Control Block Specifications](https://specs.amwa.tv/ms-05-03)
 * [BCP-002-02 NMOS Asset Distinguishing Information](https://specs.amwa.tv/bcp-002-02)
 
 <!-- INTRO-END -->

--- a/code/src/NCModel/Blocks.ts
+++ b/code/src/NCModel/Blocks.ts
@@ -34,7 +34,7 @@ export class NcBlock extends NcObject
     public constructor(
         oid: number,
         constantOid: boolean,
-        owner: number | null,
+        ownerObject: NcObject | null,
         role: string,
         userLabel: string,
         touchpoints: NcTouchpoint[] | null,
@@ -44,7 +44,7 @@ export class NcBlock extends NcObject
         description: string,
         notificationContext: INotificationContext)
     {
-        super(oid, constantOid, owner, role, userLabel, touchpoints, runtimePropertyConstraints, description, notificationContext);
+        super(oid, constantOid, ownerObject, role, userLabel, touchpoints, runtimePropertyConstraints, description, notificationContext);
 
         this.enabled = enabled;
         this.memberObjects = memberObjects;
@@ -270,6 +270,12 @@ export class NcBlock extends NcObject
         return currentClassDescriptor;
     }
 
+    public UpdateMembers(memberObjects: NcObject[])
+    {
+        this.memberObjects = memberObjects;
+        this.members = this.memberObjects.map(x => x.GenerateMemberDescriptor());
+    }
+
     public GenerateMemberDescriptors(recurse: boolean) : NcBlockMemberDescriptor[]
     {
         if(this.memberObjects != null)
@@ -411,7 +417,7 @@ export class RootBlock extends NcBlock
     public constructor(
         oid: number,
         constantOid: boolean,
-        owner: number | null,
+        ownerObject: NcObject | null,
         role: string,
         userLabel: string,
         touchpoints: NcTouchpoint[] | null,
@@ -424,7 +430,7 @@ export class RootBlock extends NcBlock
         super(
             oid,
             constantOid,
-            owner,
+            ownerObject,
             role,
             userLabel,
             touchpoints,

--- a/code/src/NCModel/Core.ts
+++ b/code/src/NCModel/Core.ts
@@ -47,10 +47,12 @@ export abstract class NcObject
 
     public description: string;
 
+    public ownerObject: NcObject | null;
+
     public constructor(
         oid: number,
         constantOid: boolean,
-        owner: number | null,
+        ownerObject: NcObject | null,
         role: string,
         userLabel: string | null,
         touchpoints: NcTouchpoint[] | null,
@@ -60,7 +62,8 @@ export abstract class NcObject
     {
         this.oid = oid;
         this.constantOid = constantOid;
-        this.owner = owner;
+        this.ownerObject = ownerObject;
+        this.owner = ownerObject?.oid ?? null;
         this.role = role;
         this.userLabel = userLabel;
         this.touchpoints = touchpoints;
@@ -184,6 +187,18 @@ export abstract class NcObject
             ],
             [ new NcEventDescriptor(new NcElementId(1, 1), "PropertyChanged", "NcPropertyChangedEventData", "Property changed event") ]
         );
+    }
+
+    public GetRolePath(): string[]
+    {
+        let rolePath: string[] = [];
+
+        if(this.ownerObject != null)
+            rolePath = rolePath.concat(this.ownerObject.GetRolePath())
+
+        rolePath = rolePath.concat([ this.role ]);
+
+        return rolePath;
     }
 }
 

--- a/code/src/NCModel/Features.ts
+++ b/code/src/NCModel/Features.ts
@@ -34,7 +34,7 @@ export abstract class NcWorker extends NcObject
     public constructor(
         oid: number,
         constantOid: boolean,
-        owner: number | null,
+        ownerObject: NcObject | null,
         role: string,
         userLabel: string,
         touchpoints: NcTouchpoint[],
@@ -43,7 +43,7 @@ export abstract class NcWorker extends NcObject
         description: string,
         notificationContext: INotificationContext)
     {
-        super(oid, constantOid, owner, role, userLabel, touchpoints, runtimePropertyConstraints, description, notificationContext);
+        super(oid, constantOid, ownerObject, role, userLabel, touchpoints, runtimePropertyConstraints, description, notificationContext);
 
         this.enabled = enabled;
     }
@@ -125,7 +125,7 @@ export class GainControl extends NcWorker
     public constructor(
         oid: number,
         constantOid: boolean,
-        owner: number | null,
+        ownerObject: NcObject | null,
         role: string,
         userLabel: string,
         touchpoints: NcTouchpoint[],
@@ -135,7 +135,7 @@ export class GainControl extends NcWorker
         description: string,
         notificationContext: INotificationContext)
     {
-        super(oid, constantOid, owner, role, userLabel, touchpoints, runtimePropertyConstraints, enabled, description, notificationContext);
+        super(oid, constantOid, ownerObject, role, userLabel, touchpoints, runtimePropertyConstraints, enabled, description, notificationContext);
 
         this.gainValue = gainValue;
     }
@@ -217,7 +217,7 @@ export class NcIdentBeacon extends NcWorker
     public constructor(
         oid: number,
         constantOid: boolean,
-        owner: number | null,
+        ownerObject: NcObject | null,
         role: string,
         userLabel: string,
         touchpoints: NcTouchpoint[],
@@ -227,7 +227,7 @@ export class NcIdentBeacon extends NcWorker
         description: string,
         notificationContext: INotificationContext)
     {
-        super(oid, constantOid, owner, role, userLabel, touchpoints, runtimePropertyConstraints, enabled, description, notificationContext);
+        super(oid, constantOid, ownerObject, role, userLabel, touchpoints, runtimePropertyConstraints, enabled, description, notificationContext);
 
         this.active = active;
     }
@@ -363,7 +363,7 @@ export class NcReceiverMonitor extends NcWorker
     public constructor(
         oid: number,
         constantOid: boolean,
-        owner: number | null,
+        ownerObject: NcObject | null,
         role: string,
         userLabel: string,
         touchpoints: NcTouchpoint[],
@@ -372,7 +372,7 @@ export class NcReceiverMonitor extends NcWorker
         description: string,
         notificationContext: INotificationContext)
     {
-        super(oid, constantOid, owner, role, userLabel, touchpoints, runtimePropertyConstraints, enabled, description, notificationContext);
+        super(oid, constantOid, ownerObject, role, userLabel, touchpoints, runtimePropertyConstraints, enabled, description, notificationContext);
 
         this.connectionStatus = NcConnectionStatus.Undefined;
         this.connectionStatusMessage = null;
@@ -492,7 +492,7 @@ export class NcReceiverMonitorProtected extends NcReceiverMonitor
     public constructor(
         oid: number,
         constantOid: boolean,
-        owner: number | null,
+        ownerObject: NcObject | null,
         role: string,
         userLabel: string,
         touchpoints: NcTouchpoint[],
@@ -501,7 +501,7 @@ export class NcReceiverMonitorProtected extends NcReceiverMonitor
         description: string,
         notificationContext: INotificationContext)
     {
-        super(oid, constantOid, owner, role, userLabel, touchpoints, runtimePropertyConstraints, enabled, description, notificationContext);
+        super(oid, constantOid, ownerObject, role, userLabel, touchpoints, runtimePropertyConstraints, enabled, description, notificationContext);
 
         this.connectionStatus = NcConnectionStatus.Undefined;
         this.connectionStatusMessage = null;
@@ -692,7 +692,7 @@ export class ExampleControl extends NcWorker
     public constructor(
         oid: number,
         constantOid: boolean,
-        owner: number | null,
+        ownerObject: NcObject | null,
         role: string,
         userLabel: string,
         touchpoints: NcTouchpoint[],
@@ -701,7 +701,7 @@ export class ExampleControl extends NcWorker
         description: string,
         notificationContext: INotificationContext)
     {
-        super(oid, constantOid, owner, role, userLabel, touchpoints, runtimePropertyConstraints, enabled, description, notificationContext);
+        super(oid, constantOid, ownerObject, role, userLabel, touchpoints, runtimePropertyConstraints, enabled, description, notificationContext);
 
         this.enumProperty = ExampleEnum.Undefined;
         this.stringProperty = "test";

--- a/code/src/NCModel/Managers.ts
+++ b/code/src/NCModel/Managers.ts
@@ -59,7 +59,7 @@ export abstract class NcManager extends NcObject
     public constructor(
         oid: number,
         constantOid: boolean,
-        owner: number | null,
+        ownerObject: NcObject | null,
         role: string,
         userLabel: string,
         touchpoints: NcTouchpoint[] | null,
@@ -67,7 +67,7 @@ export abstract class NcManager extends NcObject
         description: string,
         notificationContext: INotificationContext)
     {
-        super(oid, constantOid, owner, role, userLabel, touchpoints, runtimePropertyConstraints, description, notificationContext);
+        super(oid, constantOid, ownerObject, role, userLabel, touchpoints, runtimePropertyConstraints, description, notificationContext);
     }
 
     public static override GetClassDescriptor(includeInherited: boolean): NcClassDescriptor
@@ -256,14 +256,14 @@ export class NcDeviceManager extends NcManager
     public constructor(
         oid: number,
         constantOid: boolean,
-        owner: number | null,
+        ownerObject: NcObject | null,
         userLabel: string,
         touchpoints: NcTouchpoint[] | null,
         runtimePropertyConstraints: NcPropertyConstraints[] | null,
         description: string,
         notificationContext: INotificationContext)
     {
-        super(oid, constantOid, owner, NcDeviceManager.staticRole, userLabel, touchpoints, runtimePropertyConstraints, description, notificationContext);
+        super(oid, constantOid, ownerObject, NcDeviceManager.staticRole, userLabel, touchpoints, runtimePropertyConstraints, description, notificationContext);
 
         this.manufacturer = new NcManufacturer("Mock manufacturer", "https://specs.amwa.tv/nmos/");
         this.product = new NcProduct("Mock device", "mock-001", "1.0.0", "Mock brand", "2dcd15f6-aecc-4f01-bf66-b1044c677ef4", "Mock device for testing and prototyping");
@@ -404,14 +404,14 @@ export class NcClassManager extends NcManager
     public constructor(
         oid: number,
         constantOid: boolean,
-        owner: number | null,
+        ownerObject: NcObject | null,
         userLabel: string,
         touchpoints: NcTouchpoint[] | null,
         runtimePropertyConstraints: NcPropertyConstraints[] | null,
         description: string,
         notificationContext: INotificationContext)
     {
-        super(oid, constantOid, owner, NcClassManager.staticRole, userLabel, touchpoints, runtimePropertyConstraints, description, notificationContext);
+        super(oid, constantOid, ownerObject, NcClassManager.staticRole, userLabel, touchpoints, runtimePropertyConstraints, description, notificationContext);
 
         this.controlClassesRegister = this.GenerateClassDescriptors();
         this.controlClasses = Object.values(this.controlClassesRegister);

--- a/code/src/Server.ts
+++ b/code/src/Server.ts
@@ -102,10 +102,6 @@ try
         "The class manager offers access to control class and data type descriptors",
         sessionManager);
 
-    
-
-    
-
     const exampleControl = new ExampleControl(
         111,
         true,

--- a/code/src/Server.ts
+++ b/code/src/Server.ts
@@ -69,86 +69,6 @@ try
 
     const sessionManager = new SessionManager(config.notify_without_subscriptions);
 
-    const deviceManager = new NcDeviceManager(
-        2,
-        true,
-        1,
-        'Device manager',
-        null,
-        null,
-        "The device manager offers information about the product this device is representing",
-        sessionManager);
-
-    const classManager = new NcClassManager(
-        3,
-        true,
-        1,
-        'Class manager',
-        null,
-        null,
-        "The class manager offers access to control class and data type descriptors",
-        sessionManager);
-
-    const receiverMonitorAgent = new NcReceiverMonitor(
-        11,
-        true,
-        1,
-        'ReceiverMonitor_01',
-        'Receiver monitor 01',
-        [ new NcTouchpointNmos('x-nmos', new NcTouchpointResourceNmos('receiver', myVideoReceiver.id)) ],
-        null,
-        true,
-        "Receiver monitor worker",
-        sessionManager);
-
-    myVideoReceiver.AttachMonitoringAgent(receiverMonitorAgent);
-
-    const exampleControl = new ExampleControl(
-        111,
-        true,
-        1,
-        'ExampleControl',
-        'Example control worker',
-        [],
-        null,
-        true,
-        "Example control worker",
-        sessionManager);
-
-    const channelGainBlock = new NcBlock(
-        21,
-        true,
-        31,
-        'channel-gain',
-        'Channel gain',
-        null,
-        null,
-        true,
-        [
-            new GainControl(22, true, 21, "left-gain", "Left gain", [], null, true, 0, "Left channel gain", sessionManager),
-            new GainControl(23, true, 21, "right-gain", "Right gain", [], null, true, 0, "Right channel gain", sessionManager)
-        ],
-        "Channel gain block",
-        sessionManager);
-
-    const stereoGainBlock = new NcBlock(
-        31,
-        true,
-        1,
-        'stereo-gain',
-        'Stereo gain',
-        null,
-        null,
-        true,
-        [
-            channelGainBlock,
-            new GainControl(24, true, 31, "master-gain", "Master gain", [], null, true, 0, "Master gain", sessionManager)
-        ],
-        "Stereo gain block",
-        sessionManager);
-
-    const identBeacon = new NcIdentBeacon(51, true, 1, "IdentBeacon", "Identification beacon", [], null, true, false, "Identification beacon", sessionManager);
-
     const rootBlock = new RootBlock(
         1,
         true,
@@ -158,9 +78,113 @@ try
         null,
         null,
         true,
-        [ deviceManager, classManager, receiverMonitorAgent, stereoGainBlock, exampleControl, identBeacon ],
+        [],
         "Root block",
         sessionManager);
+
+    const deviceManager = new NcDeviceManager(
+        2,
+        true,
+        rootBlock,
+        'Device manager',
+        null,
+        null,
+        "The device manager offers information about the product this device is representing",
+        sessionManager);
+
+    const classManager = new NcClassManager(
+        3,
+        true,
+        rootBlock,
+        'Class manager',
+        null,
+        null,
+        "The class manager offers access to control class and data type descriptors",
+        sessionManager);
+
+    
+
+    
+
+    const exampleControl = new ExampleControl(
+        111,
+        true,
+        rootBlock,
+        'ExampleControl',
+        'Example control worker',
+        [],
+        null,
+        true,
+        "Example control worker",
+        sessionManager);
+
+    const stereoGainBlock = new NcBlock(
+        31,
+        true,
+        rootBlock,
+        'stereo-gain',
+        'Stereo gain',
+        null,
+        null,
+        true,
+        [],
+        "Stereo gain block",
+        sessionManager);
+
+    const channelGainBlock = new NcBlock(
+        21,
+        true,
+        stereoGainBlock,
+        'channel-gain',
+        'Channel gain',
+        null,
+        null,
+        true,
+        [],
+        "Channel gain block",
+        sessionManager);
+
+    let leftGain = new GainControl(22, true, channelGainBlock, "left-gain", "Left gain", [], null, true, 0, "Left channel gain", sessionManager);
+    let rightGain = new GainControl(23, true, channelGainBlock, "right-gain", "Right gain", [], null, true, 0, "Right channel gain", sessionManager);
+
+    channelGainBlock.UpdateMembers([ leftGain, rightGain ]);
+
+    let masterGain = new GainControl(24, true, stereoGainBlock, "master-gain", "Master gain", [], null, true, 0, "Master gain", sessionManager);
+
+    stereoGainBlock.UpdateMembers([ channelGainBlock, masterGain ]);
+
+    const receiversBlock = new NcBlock(
+        10,
+        true,
+        rootBlock,
+        'receivers',
+        'Receivers',
+        null,
+        null,
+        true,
+        [],
+        "Receivers block",
+        sessionManager);
+    
+    const receiverMonitor = new NcReceiverMonitor(
+        11,
+        true,
+        receiversBlock,
+        'monitor-01',
+        'Receiver monitor 01',
+        [ new NcTouchpointNmos('x-nmos', new NcTouchpointResourceNmos('receiver', myVideoReceiver.id)) ],
+        null,
+        true,
+        "Receiver monitor worker",
+        sessionManager);
+
+    myVideoReceiver.AttachMonitoringAgent(receiverMonitor);
+
+    receiversBlock.UpdateMembers([ receiverMonitor ]);
+
+    const identBeacon = new NcIdentBeacon(51, true, rootBlock, "IdentBeacon", "Identification beacon", [], null, true, false, "Identification beacon", sessionManager);
+
+    rootBlock.UpdateMembers([ deviceManager, classManager, receiversBlock, stereoGainBlock, exampleControl, identBeacon ]);
 
     async function doAsync () {
         await registrationClient.RegisterOrUpdateResource('node', myNode);


### PR DESCRIPTION
- to match bootstrapping style used by the Config API demo
- nest the receiver monitor in a "receivers " sub-block allowing for a better FindMembersByPath example in IS-12