### PR TITLE
Various improvements

### DIFF
--- a/code/src/NCModel/Blocks.ts
+++ b/code/src/NCModel/Blocks.ts
@@ -166,14 +166,14 @@ export class NcBlock extends NcObject
                             {
                                 if('includeDerived' in args)
                                 {
-                                    let id = args['id'] as number[];
+                                    let classId = args['id'] as number[];
                                     let includeDerived = args['includeDerived'] as boolean;
                                     let recurse = args['recurse'] as boolean;
 
                                     if(recurse)
-                                        return new CommandResponseWithValue(handle, NcMethodStatus.OK, this.GenerateMemberDescriptorsByClassId(id, includeDerived, true));
+                                        return new CommandResponseWithValue(handle, NcMethodStatus.OK, this.GenerateMemberDescriptorsByClassId(classId, includeDerived, true));
                                     else
-                                        return new CommandResponseWithValue(handle, NcMethodStatus.OK, this.GenerateMemberDescriptorsByClassId(id, includeDerived, false));
+                                        return new CommandResponseWithValue(handle, NcMethodStatus.OK, this.GenerateMemberDescriptorsByClassId(classId, includeDerived, false));
                                 }
                                 else
                                     return new CommandResponseError(handle, NcMethodStatus.InvalidRequest, 'No includeDerived argument provided');
@@ -250,7 +250,7 @@ export class NcBlock extends NcObject
                     new NcParameterDescriptor("recurse", "NcBoolean", false,  false, null, "TRUE to search nested blocks")
                 ], "Finds members with given role name or fragment"),
                 new NcMethodDescriptor(new NcElementId(2, 4), "FindMembersByClassId", "NcMethodResultBlockMemberDescriptors", [
-                    new NcParameterDescriptor("id", "NcClassId", false, false, null, "Class id to search for"),
+                    new NcParameterDescriptor("classId", "NcClassId", false, false, null, "Class id to search for"),
                     new NcParameterDescriptor("includeDerived", "NcBoolean", false,  false, null, "If TRUE it will also include derived class descriptors"),
                     new NcParameterDescriptor("recurse", "NcBoolean", false,  false, null, "TRUE to search nested blocks")
                 ], "Finds members with given class id")

--- a/code/src/NCModel/Blocks.ts
+++ b/code/src/NCModel/Blocks.ts
@@ -162,11 +162,11 @@ export class NcBlock extends NcObject
                     {
                         if(args != null)
                         {
-                            if('id' in args)
+                            if('classId' in args)
                             {
                                 if('includeDerived' in args)
                                 {
-                                    let classId = args['id'] as number[];
+                                    let classId = args['classId'] as number[];
                                     let includeDerived = args['includeDerived'] as boolean;
                                     let recurse = args['recurse'] as boolean;
 

--- a/code/src/NCModel/Features.ts
+++ b/code/src/NCModel/Features.ts
@@ -1220,6 +1220,57 @@ export class ExampleControl extends NcWorker
                         else
                             return new CommandResponseError(handle, NcMethodStatus.InvalidRequest, 'Invalid arguments provided');
                     }
+                case '1m7': //GetSequenceLength
+                    {
+                        if(args != null &&
+                            'id' in args)
+                        {
+                            let propertyId = args['id'] as NcElementId;
+                            if(propertyId)
+                            {
+                                let propertyKey: string = `${propertyId.level}p${propertyId.index}`;
+                                switch(propertyKey)
+                                {
+                                    case '3p9':
+                                        {
+                                            let length = this.stringSequence.length;
+
+                                            return new CommandResponseWithValue(handle, NcMethodStatus.OK, length);
+                                        }
+                                    case '3p10':
+                                        {
+                                            let length = this.booleanSequence.length;
+
+                                            return new CommandResponseWithValue(handle, NcMethodStatus.OK, length);
+                                        }
+                                    case '3p11':
+                                        {
+                                            let length = this.enumSequence.length;
+
+                                            return new CommandResponseWithValue(handle, NcMethodStatus.OK, length);
+                                        }
+                                    case '3p12':
+                                        {
+                                            let length = this.numberSequence.length;
+
+                                            return new CommandResponseWithValue(handle, NcMethodStatus.OK, length);
+                                        }
+                                    case '3p13':
+                                        {
+                                            let length = this.objectSequence.length;
+
+                                            return new CommandResponseWithValue(handle, NcMethodStatus.OK, length);
+                                        }
+                                    default:
+                                        return new CommandResponseError(handle, NcMethodStatus.InvalidRequest, 'Property could not be found');
+                                }
+                            }
+                            else
+                                return new CommandResponseError(handle, NcMethodStatus.InvalidRequest, 'Invalid id argument provided');
+                        }
+                        else
+                            return new CommandResponseError(handle, NcMethodStatus.InvalidRequest, 'Invalid arguments provided');
+                    }
                 case '3m1':
                     {
                         this.methodNoArgsCount = this.methodNoArgsCount + 1;
@@ -1300,7 +1351,7 @@ export class ExampleControl extends NcWorker
                 new NcPropertyDescriptor(new NcElementId(3, 1), "enumProperty", "ExampleEnum", false, false, false, false, null, "Example enum property"),
                 new NcPropertyDescriptor(new NcElementId(3, 2), "stringProperty", "NcString", false, false, false, false, new NcParameterConstraintsString(10, null),
                     "Example string property"),
-                new NcPropertyDescriptor(new NcElementId(3, 3), "numberProperty", "NcUint64", false, false, false, false, new NcParameterConstraintsNumber(1000, 0, 1),
+                new NcPropertyDescriptor(new NcElementId(3, 3), "numberProperty", "NcUint64", false, false, false, false, new NcParameterConstraintsNumber(1000, 0, 1, 3),
                     "Example numeric property"),
                 new NcPropertyDescriptor(new NcElementId(3, 4), "booleanProperty", "NcBoolean", false, false, false, false, null, "Example boolean property"),
                 new NcPropertyDescriptor(new NcElementId(3, 5), "objectProperty", "ExampleDataType", false, false, false, false, null, "Example object property"),

--- a/code/src/NCModel/Managers.ts
+++ b/code/src/NCModel/Managers.ts
@@ -452,11 +452,11 @@ export class NcClassManager extends NcManager
             {
                 case '3m1':
                     {
-                        if(args != null && 'identity' in args)
+                        if(args != null && 'classId' in args)
                         {
                             if('includeInherited' in args)
                             {
-                                let classId = args['identity'] as number[];
+                                let classId = args['classId'] as number[];
                                 let includeInherited = args['includeInherited'] as boolean;
 
                                 if(includeInherited)

--- a/code/src/NCModel/Managers.ts
+++ b/code/src/NCModel/Managers.ts
@@ -28,6 +28,7 @@ import {
     NcMethodResultDatatypeDescriptor,
     NcMethodResultError,
     NcMethodResultId,
+    NcMethodResultLength,
     NcMethodResultPropertyValue,
     NcMethodStatus,
     NcObject,
@@ -222,7 +223,7 @@ export class NcDeviceManager extends NcManager
     public override classID: number[] = NcDeviceManager.staticClassID;
 
     @myIdDecorator('3p1')
-    public ncVersion: string = "1.0.0";
+    public ncVersion: string = "v1.0.0";
 
     @myIdDecorator('3p2')
     public manufacturer: NcManufacturer;
@@ -455,12 +456,12 @@ export class NcClassManager extends NcManager
                         {
                             if('includeInherited' in args)
                             {
-                                let identity = args['identity'] as number[];
+                                let classId = args['identity'] as number[];
                                 let includeInherited = args['includeInherited'] as boolean;
 
                                 if(includeInherited)
                                 {
-                                    let descriptor = this.GetClassDescriptor(identity, true);
+                                    let descriptor = this.GetClassDescriptor(classId, true);
                                     if(descriptor)
                                         return new CommandResponseWithValue(handle, NcMethodStatus.OK, descriptor);
                                     else
@@ -468,7 +469,7 @@ export class NcClassManager extends NcManager
                                 }
                                 else
                                 {
-                                    let descriptor = this.GetClassDescriptor(identity, false);
+                                    let descriptor = this.GetClassDescriptor(classId, false);
                                     if(descriptor)
                                         return new CommandResponseWithValue(handle, NcMethodStatus.OK, descriptor);
                                     else
@@ -531,7 +532,7 @@ export class NcClassManager extends NcManager
             ],
             [ 
                 new NcMethodDescriptor(new NcElementId(3, 1), "GetControlClass", "NcMethodResultClassDescriptor", [
-                    new NcParameterDescriptor("identity", "NcClassId", false, false, null, "class ID"),
+                    new NcParameterDescriptor("classId", "NcClassId", false, false, null, "class ID"),
                     new NcParameterDescriptor("includeInherited", "NcBoolean", false, false, null, "if set the descriptor would contain all inherited elements")
                 ], "Get a single class descriptor"),
                 new NcMethodDescriptor(new NcElementId(3, 2), "GetDatatype", "NcMethodResultDatatypeDescriptor", [
@@ -680,19 +681,20 @@ export class NcClassManager extends NcManager
                 new NcEnumItemDescriptor("InvalidRequest", 406, "Method call is invalid in current operating context"),
                 new NcEnumItemDescriptor("Conflict", 409, "There is a conflict with the current state of the device"),
                 new NcEnumItemDescriptor("BufferOverflow", 413, "Something was too big"),
+                new NcEnumItemDescriptor("IndexOutOfBounds", 414, "Index is outside the available range"),
                 new NcEnumItemDescriptor("ParameterError", 417, "Method parameter does not meet expectations"),
                 new NcEnumItemDescriptor("Locked", 423, "Addressed object is locked"),
                 new NcEnumItemDescriptor("DeviceError", 500, "Internal device error"),
                 new NcEnumItemDescriptor("MethodNotImplemented", 501, "Addressed method is not implemented by the addressed object"),
                 new NcEnumItemDescriptor("PropertyNotImplemented", 502, "Addressed property is not implemented by the addressed object"),
                 new NcEnumItemDescriptor("NotReady", 503, "The device is not ready to handle any commands"),
-                new NcEnumItemDescriptor("Timeout", 504, "Method call did not finish within the allotted time"),
-                new NcEnumItemDescriptor("ProtocolVersionError", 505, "Incompatible protocol version"),
+                new NcEnumItemDescriptor("Timeout", 504, "Method call did not finish within the allotted time")
             ], null, "Method invokation status"),
             'NcMethodResult': NcMethodResult.GetTypeDescriptor(false),
             'NcMethodResultError': NcMethodResultError.GetTypeDescriptor(false),
             'NcMethodResultPropertyValue': NcMethodResultPropertyValue.GetTypeDescriptor(false),
             'NcMethodResultId': NcMethodResultId.GetTypeDescriptor(false),
+            'NcMethodResultLength': NcMethodResultLength.GetTypeDescriptor(false),
             'NcBlockMemberDescriptor': NcBlockMemberDescriptor.GetTypeDescriptor(false),
             'NcMethodResultBlockMemberDescriptors': NcMethodResultBlockMemberDescriptors.GetTypeDescriptor(false),
             'NcMethodResultClassDescriptor': NcMethodResultClassDescriptor.GetTypeDescriptor(false),
@@ -766,6 +768,7 @@ export class NcClassManager extends NcManager
             case 'NcMethodResultClassDescriptor': return NcMethodResultClassDescriptor.GetTypeDescriptor(true);
             case 'NcMethodResultDatatypeDescriptor': return NcMethodResultDatatypeDescriptor.GetTypeDescriptor(true);
             case 'NcMethodResultId': return NcMethodResultId.GetTypeDescriptor(true);
+            case 'NcMethodResultLength': return NcMethodResultLength.GetTypeDescriptor(true);
             default: return this.dataTypesRegister[name];
         }
     }

--- a/code/src/NCProtocol/Commands.ts
+++ b/code/src/NCProtocol/Commands.ts
@@ -76,7 +76,7 @@ export class ProtocolCommand extends ProtocolWrapper
     public constructor(
         commands: CommandMsg[])
     {
-        super('1.0.0', MessageType.Command);
+        super(MessageType.Command);
 
         this.commands = commands;
     }
@@ -94,7 +94,7 @@ export class ProtocolCommandResponse extends ProtocolWrapper
     public constructor(
         responses: CommandResponseNoValue[])
     {
-        super('1.0.0', MessageType.CommandResponse);
+        super(MessageType.CommandResponse);
 
         this.responses = responses;
     }
@@ -117,7 +117,7 @@ export class ProtocolSubscription extends ProtocolWrapper
     public constructor(
         subscriptions: number[])
     {
-        super('1.0.0', MessageType.Subscription);
+        super(MessageType.Subscription);
 
         this.subscriptions = subscriptions;
     }
@@ -135,7 +135,7 @@ export class ProtocolSubscriptionResponse extends ProtocolWrapper
     public constructor(
         subscriptions: number[])
     {
-        super('1.0.0', MessageType.SubscriptionResponse);
+        super(MessageType.SubscriptionResponse);
 
         this.subscriptions = subscriptions;
     }
@@ -156,7 +156,7 @@ export class ProtocolError extends ProtocolWrapper
         status: NcMethodStatus,
         errorMessage: string)
     {
-        super('1.0.0', MessageType.Error);
+        super(MessageType.Error);
 
         this.status = status;
         this.errorMessage = errorMessage;

--- a/code/src/NCProtocol/Core.ts
+++ b/code/src/NCProtocol/Core.ts
@@ -11,14 +11,11 @@ export enum MessageType {
 
 export abstract class ProtocolWrapper
 {
-    public protocolVersion: string;
     public messageType: MessageType;
 
     public constructor(
-        protocolVersion: string,
         messageType: MessageType)
     {
-        this.protocolVersion = protocolVersion;
         this.messageType = messageType;
     }
 }

--- a/code/src/NCProtocol/Notifications.ts
+++ b/code/src/NCProtocol/Notifications.ts
@@ -68,7 +68,7 @@ export class ProtocolNotification extends ProtocolWrapper
     public constructor(
         notifications: NcNotification[])
     {
-        super('1.0.0', MessageType.Notification);
+        super(MessageType.Notification);
 
         this.notifications = notifications;
     }

--- a/code/src/Server.ts
+++ b/code/src/Server.ts
@@ -230,36 +230,27 @@ try
 
                 if(message)
                 {
-                    if(message.protocolVersion == "1.0.0")
+                    switch(message.messageType)
                     {
-                        switch(message.messageType)
+                        case MessageType.Command:
                         {
-                            case MessageType.Command:
-                            {
-                                rootBlock.ProcessMessage(msg, extWs);
-                                isMessageValid = true;
-                            }
-                            break;
-                            case MessageType.Subscription:
-                            {
-                                let message = JSON.parse(msg) as ProtocolSubscription;
-                                sessionManager.ModifySubscription(extWs, message);
-                                isMessageValid = true;
-                            }
-                            break;
-                            default:
-                            {
-                                isMessageValid = false;
-                                errorMessage = `Invalid message type received: ${message.messageType}`;
-                            }
-                            break;
+                            rootBlock.ProcessMessage(msg, extWs);
+                            isMessageValid = true;
                         }
-                    }
-                    else
-                    {
-                        isMessageValid = false;
-                        errorMessage = `Unsupported protocol version`;
-                        status = NcMethodStatus.ProtocolVersionError;
+                        break;
+                        case MessageType.Subscription:
+                        {
+                            let message = JSON.parse(msg) as ProtocolSubscription;
+                            sessionManager.ModifySubscription(extWs, message);
+                            isMessageValid = true;
+                        }
+                        break;
+                        default:
+                        {
+                            isMessageValid = false;
+                            errorMessage = `Invalid message type received: ${message.messageType}`;
+                        }
+                        break;
                     }
                 }
                 else


### PR DESCRIPTION
- protocolVersion field removed from IS-12
- NcVersionCode is (vMajor.Minor.Patch) so updated device manager
- GetSequenceLength to NcObject
- Add NcMethodResultLength datatype
- IndexOutOfBounds error status (code 414)
- Remove ProtocolVersionError status (code 505) classId naming:
- FindMembersByClassId (id-> classId)
- GetControlClass (identity -> classId)
- NcClassDescriptor (identity -> classId)
- Add example implementation for default value in constraints